### PR TITLE
Add tabSize to json file, and use it with Monaco

### DIFF
--- a/packages/marqus-desktop/src/main/schemas/config/6_addTabSize.ts
+++ b/packages/marqus-desktop/src/main/schemas/config/6_addTabSize.ts
@@ -1,0 +1,34 @@
+import { z } from "zod";
+import { ConfigV5 } from "./5_renameNoteDirectory";
+
+export interface ConfigV6 {
+  version: number;
+  windowHeight: number;
+  windowWidth: number;
+  noteDirectory?: string;
+  logDirectory?: string;
+  developerMode?: boolean;
+  autoHideAppMenu?: boolean;
+  tabSize?: number;
+}
+
+export const configSchemaV6 = z.preprocess(
+  obj => {
+    const config = obj as ConfigV5 | ConfigV6;
+    if (config.version === 5) {
+      config.version = 6;
+    }
+
+    return config;
+  },
+  z.object({
+    version: z.literal(6),
+    windowHeight: z.number().min(1),
+    windowWidth: z.number().min(1),
+    noteDirectory: z.string().optional(),
+    logDirectory: z.string(),
+    developerMode: z.boolean().optional(),
+    autoHideAppMenu: z.boolean().optional(),
+    tabSize: z.number().min(1).optional(),
+  }),
+);

--- a/packages/marqus-desktop/src/main/schemas/config/index.ts
+++ b/packages/marqus-desktop/src/main/schemas/config/index.ts
@@ -3,6 +3,7 @@ import { configSchemaV2 } from "./2_addLogDirectory";
 import { configSchemaV3 } from "./3_addDeveloperMode";
 import { configSchemaV4 } from "./4_addAutoHideAppMenu";
 import { configSchemaV5 } from "./5_renameNoteDirectory";
+import { configSchemaV6 } from "./6_addTabSize";
 
 export const CONFIG_SCHEMAS = {
   1: configSchemaV1,
@@ -10,4 +11,5 @@ export const CONFIG_SCHEMAS = {
   3: configSchemaV3,
   4: configSchemaV4,
   5: configSchemaV5,
+  6: configSchemaV6,
 };

--- a/packages/marqus-desktop/src/renderer/App.tsx
+++ b/packages/marqus-desktop/src/renderer/App.tsx
@@ -121,7 +121,7 @@ export function App(props: AppProps): JSX.Element {
   return (
     <Container>
       {!(state.sidebar.hidden ?? false) && <Sidebar store={store} />}
-      <Editor store={store} />
+      <Editor store={store} config={config} />
       {props.config.noteDirectory == null && (
         <NoteDirectoryModal store={store} />
       )}

--- a/packages/marqus-desktop/src/renderer/components/Editor.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Editor.tsx
@@ -10,15 +10,17 @@ import { ModelAndViewState, Monaco } from "./Monaco";
 import { Focusable } from "./shared/Focusable";
 import { EditorToolbar, TOOLBAR_HEIGHT } from "./EditorToolbar";
 import { getNoteById } from "../../shared/domain/note";
+import { Config } from "../../shared/domain/config";
 
 const NOTE_SAVE_INTERVAL_MS = 500;
 
 interface EditorProps {
   store: Store;
+  config: Config;
 }
 
 export function Editor(props: EditorProps): JSX.Element {
-  const { store } = props;
+  const { store, config } = props;
   const { state } = store;
   const { editor } = state;
 
@@ -49,6 +51,7 @@ export function Editor(props: EditorProps): JSX.Element {
       content = (
         <Monaco
           store={store}
+          config={config}
           modelAndViewStateCache={modelAndViewStateCache.current}
           updateCache={updateCache}
           removeCache={removeCache}

--- a/packages/marqus-desktop/src/renderer/components/Monaco.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Monaco.tsx
@@ -5,6 +5,7 @@ import * as monaco from "monaco-editor";
 import { TOOLBAR_HEIGHT } from "./EditorToolbar";
 import { Section } from "../../shared/ui/app";
 import { Attachment, Protocol } from "../../shared/domain/protocols";
+import { Config } from "../../shared/domain/config";
 
 const MONACO_SETTINGS: monaco.editor.IStandaloneEditorConstructionOptions = {
   language: "markdown",
@@ -33,13 +34,14 @@ export type ModelAndViewState = {
 
 export interface MonacoProps {
   store: Store;
+  config: Config;
   modelAndViewStateCache: Partial<Record<string, ModelAndViewState>>;
   updateCache: (noteId: string, mAndVS: ModelAndViewState) => void;
   removeCache: (noteId: string) => void;
 }
 
 export function Monaco(props: MonacoProps): JSX.Element {
-  const { store } = props;
+  const { store, config } = props;
   const { state } = store;
   const { editor } = state;
 
@@ -154,6 +156,7 @@ export function Monaco(props: MonacoProps): JSX.Element {
       monacoEditor.current = monaco.editor.create(el, {
         value: "",
         ...MONACO_SETTINGS,
+        tabSize: config.tabSize,
       });
 
       // Monaco doesn't automatically resize when it's container element does so

--- a/packages/marqus-desktop/src/shared/domain/config.ts
+++ b/packages/marqus-desktop/src/shared/domain/config.ts
@@ -6,4 +6,6 @@ export interface Config {
   noteDirectory?: string;
   developerMode?: boolean;
   autoHideAppMenu?: boolean;
+  // Default is 4 (comes from Monaco)
+  tabSize?: number;
 }

--- a/packages/marqus-desktop/test/renderer/components/Monaco.spec.tsx
+++ b/packages/marqus-desktop/test/renderer/components/Monaco.spec.tsx
@@ -11,6 +11,7 @@ import * as monaco from "monaco-editor";
 import { Section } from "../../../src/shared/ui/app";
 import { when } from "jest-when";
 import { Protocol } from "../../../src/shared/domain/protocols";
+import { createConfig } from "../../__factories__/config";
 
 test("importAttachments", async () => {
   const noteId = uuid();
@@ -23,10 +24,12 @@ test("importAttachments", async () => {
     },
     focused: [Section.Editor],
   });
+  const config = createConfig();
 
   const r = render(
     <Monaco
       store={store.current}
+      config={config}
       modelAndViewStateCache={{}}
       updateCache={jest.fn()}
       removeCache={jest.fn()}


### PR DESCRIPTION
Users can now specify how many spaces to use for a tab when editing markdown by setting `tabSize` in your `config.json` file.

The default is 4 spaces, min is 1.