### PR TITLE
Fix syntax highlighting in Monaco

### DIFF
--- a/packages/marqus-desktop/forge.config.js
+++ b/packages/marqus-desktop/forge.config.js
@@ -45,6 +45,8 @@ module.exports = {
     {
       name: "@electron-forge/plugin-webpack",
       config: {
+        // unsafe-eval is required for source map support in dev. We don't set
+        // it in prod so it's safe to ignore that scary warning in the console.
         devContentSecurityPolicy:
           "default-src ws://localhost:3000 http://localhost:3000 self; style-src 'unsafe-inline'; img-src * attachment://*; script-src-elem 'self' 'unsafe-eval'; script-src 'self' 'unsafe-eval';",
         mainConfig: "./webpack.main.config.js",

--- a/packages/marqus-desktop/package.json
+++ b/packages/marqus-desktop/package.json
@@ -72,6 +72,7 @@
     "date-fns": "^2.28.0",
     "electron-squirrel-startup": "^1.0.0",
     "fast-fuzzy": "^1.11.1",
+    "file-loader": "^6.2.0",
     "jquery": "^3.6.2",
     "jquery.scrollto": "^2.1.3",
     "lodash": "^4.17.21",

--- a/packages/marqus-desktop/package.json
+++ b/packages/marqus-desktop/package.json
@@ -76,7 +76,7 @@
     "jquery": "^3.6.2",
     "jquery.scrollto": "^2.1.3",
     "lodash": "^4.17.21",
-    "monaco-editor": "^0.33.0",
+    "monaco-editor": "^0.34.1",
     "monaco-editor-webpack-plugin": "^7.0.1",
     "nanoid": "^3.1.30",
     "open-color": "^1.9.1",

--- a/packages/marqus-desktop/src/renderer/components/Monaco.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Monaco.tsx
@@ -259,7 +259,7 @@ export function Monaco(props: MonacoProps): JSX.Element {
       // First load, gotta create the model.
       if (cache == null) {
         cache = {
-          model: monaco.editor.createModel(newTab.note.content ?? ""),
+          model: createMarkdownModel(newTab.note.content),
         }!;
       }
 
@@ -288,6 +288,16 @@ const StyledEditor = styled.div`
   flex-grow: 1;
   height: calc(100% - ${TOOLBAR_HEIGHT});
 `;
+
+export function createMarkdownModel(
+  content: string | undefined,
+): monaco.editor.ITextModel {
+  return monaco.editor.createModel(
+    content ?? "",
+    // N.B. Language needs to be specified for syntax highlighting.
+    "markdown",
+  );
+}
 
 export function generateAttachmentLink(attachment: Attachment): string {
   // We do this to support spaces

--- a/packages/marqus-desktop/test/renderer/components/Monaco.spec.tsx
+++ b/packages/marqus-desktop/test/renderer/components/Monaco.spec.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import {
+  createMarkdownModel,
   generateAttachmentLink,
   Monaco,
 } from "../../../src/renderer/components/Monaco";
@@ -101,6 +102,17 @@ test("importAttachments", async () => {
       },
     ],
   );
+});
+
+test("createMarkdownModel", () => {
+  const model = {
+    getEOL: jest.fn().mockReturnValue("\n"),
+    getLineCount: jest.fn().mockReturnValue(2),
+  };
+  (monaco.editor.createModel as jest.Mock).mockReturnValueOnce(model);
+
+  createMarkdownModel("foo");
+  expect(monaco.editor.createModel).toHaveBeenCalledWith("foo", "markdown");
 });
 
 test("generateAttachmentLink", () => {

--- a/packages/marqus-desktop/webpack.main.config.js
+++ b/packages/marqus-desktop/webpack.main.config.js
@@ -35,7 +35,7 @@ module.exports = {
         {
           from: "static",
           to: "static",
-        }, 
+        },
       ],
     }),
   ],

--- a/packages/marqus-desktop/webpack.renderer.config.js
+++ b/packages/marqus-desktop/webpack.renderer.config.js
@@ -1,6 +1,6 @@
-const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const ForkTsCheckerWebpackPlugin = require("fork-ts-checker-webpack-plugin");
 const Webpack = require("webpack");
+const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 
 const rules = require("./webpack.rules");
 

--- a/packages/marqus-desktop/webpack.rules.js
+++ b/packages/marqus-desktop/webpack.rules.js
@@ -24,4 +24,8 @@ module.exports = [
       "sass-loader",
     ],
   },
+  {
+    test: /\.ttf$/,
+    use: [{ loader: "file-loader" }],
+  },
 ];

--- a/yarn.lock
+++ b/yarn.lock
@@ -5285,6 +5285,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"file-loader@npm:^6.2.0":
+  version: 6.2.0
+  resolution: "file-loader@npm:6.2.0"
+  dependencies:
+    loader-utils: ^2.0.0
+    schema-utils: ^3.0.0
+  peerDependencies:
+    webpack: ^4.0.0 || ^5.0.0
+  checksum: faf43eecf233f4897b0150aaa874eeeac214e4f9de49738a9e0ef734a30b5260059e85b7edadf852b98e415f875bd5f12587768a93fd52aaf2e479ecf95fab20
+  languageName: node
+  linkType: hard
+
 "file-stream-rotator@npm:^0.6.1":
   version: 0.6.1
   resolution: "file-stream-rotator@npm:0.6.1"
@@ -8201,6 +8213,7 @@ __metadata:
     eslint-plugin-react: ^7.29.4
     eslint-plugin-react-hooks: ^4.4.0
     fast-fuzzy: ^1.11.1
+    file-loader: ^6.2.0
     fork-ts-checker-webpack-plugin: ^6.0.1
     html-webpack-plugin: ^4.5.2
     jest: ^27.3.1

--- a/yarn.lock
+++ b/yarn.lock
@@ -8222,7 +8222,7 @@ __metadata:
     jquery.scrollto: ^2.1.3
     lodash: ^4.17.21
     mock-fs: ^5.2.0
-    monaco-editor: ^0.33.0
+    monaco-editor: ^0.34.1
     monaco-editor-webpack-plugin: ^7.0.1
     nanoid: ^3.1.30
     node-loader: ^2.0.0
@@ -8724,10 +8724,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"monaco-editor@npm:^0.33.0":
-  version: 0.33.0
-  resolution: "monaco-editor@npm:0.33.0"
-  checksum: f88fd1c9be0d6845436aa92ee7f7bcc49f9e9bf452f73bb5efbbe52e50678d1c2aec4d612a943310f5e2282c1d9fcc41b792b65a5b9008e6054908e7e10311ea
+"monaco-editor@npm:^0.34.1":
+  version: 0.34.1
+  resolution: "monaco-editor@npm:0.34.1"
+  checksum: 4c6b35d7c566ec414b758cdd45dfb08d6fe46e2e8fdeed88b619a52c47592ce6df476d9490a58e5d450339c4a93f09d500adc9c017a348179277b98aa6009fa4
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Turns out Monaco supports syntax highlighting for Markdown by default but we never specified the language when creating text models.

This just helps provide more real-time feedback for when users are writing Markdown and is a quality of life mod:
![fixed](https://user-images.githubusercontent.com/25796180/215004481-b241c015-00d9-4887-a104-f4f0893bf08c.png)
