### PR TITLE
Add bold and italic shortcut

### DIFF
--- a/packages/marqus-desktop/src/renderer/components/Editor.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Editor.tsx
@@ -45,6 +45,20 @@ export function Editor(props: EditorProps): JSX.Element {
     activeTab = editor.tabs.find(t => t.note.id === editor.activeTabNoteId);
   }
 
+  useEffect(() => {
+    store.on("editor.setContent", setContent);
+    store.on("editor.save", save);
+    store.on("editor.toggleView", toggleView);
+    store.on("editor.updateScroll", updateScroll);
+
+    return () => {
+      store.off("editor.setContent", setContent);
+      store.off("editor.save", save);
+      store.off("editor.toggleView", toggleView);
+      store.off("editor.updateScroll", updateScroll);
+    };
+  }, [store]);
+
   let content;
   if (activeTab) {
     if (editor.isEditing) {
@@ -70,20 +84,6 @@ export function Editor(props: EditorProps): JSX.Element {
       );
     }
   }
-
-  useEffect(() => {
-    store.on("editor.setContent", setContent);
-    store.on("editor.save", save);
-    store.on("editor.toggleView", toggleView);
-    store.on("editor.updateScroll", updateScroll);
-
-    return () => {
-      store.off("editor.setContent", setContent);
-      store.off("editor.save", save);
-      store.off("editor.toggleView", toggleView);
-      store.off("editor.updateScroll", updateScroll);
-    };
-  }, [store]);
 
   return (
     <StyledFocusable

--- a/packages/marqus-desktop/src/renderer/components/Monaco.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Monaco.tsx
@@ -388,6 +388,7 @@ export function disableKeybinding(
   editor: monaco.editor.IStandaloneCodeEditor,
   commandId: string,
 ): void {
+  // See: https://github.com/microsoft/monaco-editor/issues/102
   const { _standaloneKeybindingService } = editor as any;
 
   _standaloneKeybindingService.addDynamicKeybinding(

--- a/packages/marqus-desktop/src/shared/io/defaultShortcuts.ts
+++ b/packages/marqus-desktop/src/shared/io/defaultShortcuts.ts
@@ -46,7 +46,7 @@ const shortcuts: Shortcut[] = [
   {
     name: "app.toggleSidebar",
     event: "app.toggleSidebar",
-    keys: [KeyCode.Control, KeyCode.LetterB],
+    keys: [KeyCode.Control, KeyCode.Shift, KeyCode.LetterB],
   },
   {
     name: "sidebar.focusSearch",
@@ -165,6 +165,11 @@ const shortcuts: Shortcut[] = [
     name: "editor.nextTab",
     event: "editor.nextTab",
     keys: [KeyCode.Control, KeyCode.Tab],
+  },
+  {
+    name: "editor.boldSelectedText",
+    event: "editor.boldSelectedText",
+    keys: [KeyCode.Control, KeyCode.LetterB],
   },
 ];
 

--- a/packages/marqus-desktop/src/shared/io/defaultShortcuts.ts
+++ b/packages/marqus-desktop/src/shared/io/defaultShortcuts.ts
@@ -171,6 +171,11 @@ const shortcuts: Shortcut[] = [
     event: "editor.boldSelectedText",
     keys: [KeyCode.Control, KeyCode.LetterB],
   },
+  {
+    name: "editor.italicSelectedText",
+    event: "editor.italicSelectedText",
+    keys: [KeyCode.Control, KeyCode.LetterI],
+  },
 ];
 
 export const DEFAULT_SHORTCUTS = shortcuts.map(s => ({

--- a/packages/marqus-desktop/src/shared/ui/events.ts
+++ b/packages/marqus-desktop/src/shared/ui/events.ts
@@ -72,6 +72,7 @@ export interface UIEvents {
   "editor.nextTab": void;
   "editor.updateTabsScroll": number;
   "editor.boldSelectedText": void;
+  "editor.italicSelectedText": void;
 
   // Focus Tracker
   "focus.push": Section | Section[];
@@ -148,6 +149,7 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "editor.nextTab",
   "editor.updateTabsScroll",
   "editor.boldSelectedText",
+  "editor.italicSelectedText",
 
   // Focus Tracker
   "focus.push",

--- a/packages/marqus-desktop/src/shared/ui/events.ts
+++ b/packages/marqus-desktop/src/shared/ui/events.ts
@@ -71,6 +71,7 @@ export interface UIEvents {
   "editor.previousTab": void;
   "editor.nextTab": void;
   "editor.updateTabsScroll": number;
+  "editor.boldSelectedText": void;
 
   // Focus Tracker
   "focus.push": Section | Section[];
@@ -146,6 +147,7 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "editor.previousTab",
   "editor.nextTab",
   "editor.updateTabsScroll",
+  "editor.boldSelectedText",
 
   // Focus Tracker
   "focus.push",

--- a/packages/marqus-desktop/test/__mocks__/monaco.ts
+++ b/packages/marqus-desktop/test/__mocks__/monaco.ts
@@ -5,4 +5,7 @@
 export const editor = {
   create: jest.fn(),
   createModel: jest.fn(),
+  _standaloneKeybindingService: {
+    addDynamicKeybinding: jest.fn(),
+  },
 };

--- a/packages/marqus-desktop/test/renderer/components/Monaco.spec.tsx
+++ b/packages/marqus-desktop/test/renderer/components/Monaco.spec.tsx
@@ -50,7 +50,7 @@ test("importAttachments", async () => {
     setModel: jest.fn(),
     dispose: jest.fn(),
   };
-  (monaco.editor.create as jest.Mock).mockReturnValueOnce(monacoEditor);
+  (monaco.editor.create as jest.Mock).mockReturnValue(monacoEditor);
   (monaco.editor.createModel as jest.Mock).mockReturnValueOnce(model);
 
   when((window as any).ipc as jest.Mock)


### PR DESCRIPTION
- Shortcut to hide sidebar has been changed to `ctrl+shift+b`.
- New shortcut to bold selected text in editor has been added via `ctrl+b`
- New shortcut to italicize selected text in editor has been added via `ctrl+i`