### PR TITLE
Allow saving Monaco viewstates so they can be restored on re-open.

### DIFF
--- a/packages/marqus-desktop/src/main/ipc/plugins/app.ts
+++ b/packages/marqus-desktop/src/main/ipc/plugins/app.ts
@@ -25,7 +25,7 @@ import { getConfigDirectory } from "./config";
 
 export const APP_STATE_FILE = "appState.json";
 export const APP_STATE_DEFAULTS = {
-  version: 1,
+  version: 2,
   sidebar: {
     scroll: 0,
     sort: NoteSort.Alphanumeric,
@@ -80,14 +80,14 @@ export const appIpcPlugin: IpcPlugin = {
   },
 
   "app.saveAppState": async (ctx, appState) => {
-    if (appStateFile == null) {
-      return;
-    }
-
     const { blockAppFromQuitting } = ctx;
 
     await blockAppFromQuitting(async () => {
-      await appStateFile!.update(appState);
+      if (appStateFile == null) {
+        return;
+      }
+
+      await appStateFile.update(appState);
     });
   },
 

--- a/packages/marqus-desktop/src/main/schemas/appState/2_addViewState.ts
+++ b/packages/marqus-desktop/src/main/schemas/appState/2_addViewState.ts
@@ -1,0 +1,76 @@
+import { app } from "electron";
+import { z } from "zod";
+import { AppStateV1 } from "./1_initialDefinition";
+import { ModelViewState, Section } from "../../../shared/ui/app";
+import { DATE_OR_STRING_SCHEMA, PX_REGEX } from "../../../shared/domain";
+import { NoteSort } from "../../../shared/domain/note";
+
+export interface AppStateV2 {
+  version: number;
+  sidebar: Sidebar;
+  editor: Editor;
+  focused: Section[];
+}
+
+interface Sidebar {
+  searchString?: string;
+  hidden?: boolean;
+  width: string;
+  scroll: number;
+  selected?: string[];
+  expanded?: string[];
+  sort: NoteSort;
+}
+
+interface Editor {
+  isEditing: boolean;
+  scroll: number;
+  tabs: EditorTab[];
+  tabsScroll: number;
+  activeTabNoteId?: string;
+}
+
+interface EditorTab {
+  noteId: string;
+  noteContent?: string;
+  lastActive?: Date | string;
+  viewState?: ModelViewState["viewState"];
+}
+
+export const appStateV2 = z.preprocess(
+  obj => {
+    const state = obj as AppStateV1 | AppStateV2;
+    if (state.version === 1) {
+      state.version = 2;
+    }
+
+    return state;
+  },
+  z.object({
+    version: z.literal(2),
+    sidebar: z.object({
+      width: z.string().regex(PX_REGEX),
+      scroll: z.number(),
+      hidden: z.boolean().optional(),
+      selected: z.array(z.string()).optional(),
+      expanded: z.array(z.string()).optional(),
+      sort: z.nativeEnum(NoteSort),
+      searchString: z.string().optional(),
+    }),
+    editor: z.object({
+      isEditing: z.boolean(),
+      scroll: z.number(),
+      tabs: z.array(
+        z.object({
+          noteId: z.string(),
+          // Intentionally omitted noteContent
+          lastActive: DATE_OR_STRING_SCHEMA.optional(),
+          viewState: z.any().optional(),
+        }),
+      ),
+      tabsScroll: z.number(),
+      activeTabNoteId: z.string().optional(),
+    }),
+    focused: z.array(z.nativeEnum(Section)),
+  }),
+);

--- a/packages/marqus-desktop/src/main/schemas/appState/index.ts
+++ b/packages/marqus-desktop/src/main/schemas/appState/index.ts
@@ -1,5 +1,7 @@
 import { appStateV1 } from "./1_initialDefinition";
+import { appStateV2 } from "./2_addViewState";
 
 export const APP_STATE_SCHEMAS = {
   1: appStateV1,
+  2: appStateV2,
 };

--- a/packages/marqus-desktop/src/renderer/components/Editor.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Editor.tsx
@@ -1,5 +1,5 @@
 import { debounce } from "lodash";
-import React, { useCallback, useEffect, useRef } from "react";
+import React, { useEffect } from "react";
 import styled from "styled-components";
 import { Section } from "../../shared/ui/app";
 import { Ipc } from "../../shared/ipc";
@@ -34,12 +34,14 @@ export function Editor(props: EditorProps): JSX.Element {
     store.on("editor.save", save);
     store.on("editor.toggleView", toggleView);
     store.on("editor.updateScroll", updateScroll);
+    store.on("editor.deleteModelViewState", deleteModelViewState);
 
     return () => {
       store.off("editor.setContent", setContent);
       store.off("editor.save", save);
       store.off("editor.toggleView", toggleView);
       store.off("editor.updateScroll", updateScroll);
+      store.off("editor.deleteModelViewState", deleteModelViewState);
     };
   }, [store]);
 
@@ -164,6 +166,24 @@ export const updateScroll: Listener<"editor.updateScroll"> = (
   ctx.setUI({
     editor: {
       scroll,
+    },
+  });
+};
+
+// deleteModelViewState can be called after the Monaco component has unmounted so
+// we have to register the listener in the Editor parent.
+export const deleteModelViewState: Listener<"editor.deleteModelViewState"> = (
+  { value },
+  ctx,
+) => {
+  if (value == null) {
+    return;
+  }
+
+  console.log("Delete model view state!");
+  ctx.setCache({
+    modelViewStates: {
+      [value]: undefined,
     },
   });
 };

--- a/packages/marqus-desktop/src/renderer/components/Editor.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Editor.tsx
@@ -6,7 +6,7 @@ import { Ipc } from "../../shared/ipc";
 import { m3 } from "../css";
 import { Listener, Store } from "../store";
 import { Markdown } from "./Markdown";
-import { ModelAndViewState, Monaco } from "./Monaco";
+import { Monaco } from "./Monaco";
 import { Focusable } from "./shared/Focusable";
 import { EditorToolbar, TOOLBAR_HEIGHT } from "./EditorToolbar";
 import { getNoteById } from "../../shared/domain/note";
@@ -23,22 +23,6 @@ export function Editor(props: EditorProps): JSX.Element {
   const { store, config } = props;
   const { state } = store;
   const { editor } = state;
-
-  // N.B. We cache the model and view state for monaco tabs here in the Editor
-  // vs within the Monaco component because the Monaco component gets unmounted
-  // when the editor switches to view mode so we'd lose tab states.
-  //
-  // TODO: Move these up to the store?
-  const modelAndViewStateCache = useRef<Record<string, ModelAndViewState>>({});
-  const updateCache = useCallback(
-    (noteId: string, modelAndViewState: ModelAndViewState) => {
-      modelAndViewStateCache.current[noteId] = modelAndViewState;
-    },
-    [],
-  );
-  const removeCache = useCallback((noteId: string) => {
-    delete modelAndViewStateCache.current[noteId];
-  }, []);
 
   let activeTab;
   if (editor.activeTabNoteId != null) {
@@ -62,15 +46,7 @@ export function Editor(props: EditorProps): JSX.Element {
   let content;
   if (activeTab) {
     if (editor.isEditing) {
-      content = (
-        <Monaco
-          store={store}
-          config={config}
-          modelAndViewStateCache={modelAndViewStateCache.current}
-          updateCache={updateCache}
-          removeCache={removeCache}
-        />
-      );
+      content = <Monaco store={store} config={config} />;
     } else {
       content = (
         <Markdown

--- a/packages/marqus-desktop/src/renderer/components/Editor.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Editor.tsx
@@ -34,14 +34,12 @@ export function Editor(props: EditorProps): JSX.Element {
     store.on("editor.save", save);
     store.on("editor.toggleView", toggleView);
     store.on("editor.updateScroll", updateScroll);
-    store.on("editor.deleteModelViewState", deleteModelViewState);
 
     return () => {
       store.off("editor.setContent", setContent);
       store.off("editor.save", save);
       store.off("editor.toggleView", toggleView);
       store.off("editor.updateScroll", updateScroll);
-      store.off("editor.deleteModelViewState", deleteModelViewState);
     };
   }, [store]);
 
@@ -166,24 +164,6 @@ export const updateScroll: Listener<"editor.updateScroll"> = (
   ctx.setUI({
     editor: {
       scroll,
-    },
-  });
-};
-
-// deleteModelViewState can be called after the Monaco component has unmounted so
-// we have to register the listener in the Editor parent.
-export const deleteModelViewState: Listener<"editor.deleteModelViewState"> = (
-  { value },
-  ctx,
-) => {
-  if (value == null) {
-    return;
-  }
-
-  console.log("Delete model view state!");
-  ctx.setCache({
-    modelViewStates: {
-      [value]: undefined,
     },
   });
 };

--- a/packages/marqus-desktop/src/renderer/components/Monaco.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Monaco.tsx
@@ -30,9 +30,6 @@ const MONACO_SETTINGS: monaco.editor.IStandaloneEditorConstructionOptions = {
 export interface MonacoProps {
   store: Store;
   config: Config;
-  // modelAndViewStateCache: Partial<Record<string, ModelAndViewState>>;
-  // updateCache: (noteId: string, mAndVS: ModelAndViewState) => void;
-  // removeCache: (noteId: string) => void;
 }
 
 export function Monaco(props: MonacoProps): JSX.Element {
@@ -49,15 +46,12 @@ export function Monaco(props: MonacoProps): JSX.Element {
 
   // Need to sub before doing anything or else we get no listener error.
   useEffect(() => {
-    console.log("Sub to set model view state!");
-
     store.on("editor.boldSelectedText", boldSelectedText);
     store.on("editor.italicSelectedText", italicSelectedText);
     store.on("editor.setModelViewState", setModelViewState);
     store.on("editor.deleteModelViewState", deleteModelViewState);
 
     return () => {
-      console.log("Remove model view state listeners.");
       store.off("editor.boldSelectedText", boldSelectedText);
       store.off("editor.italicSelectedText", italicSelectedText);
       store.off("editor.setModelViewState", setModelViewState);
@@ -230,7 +224,6 @@ export function Monaco(props: MonacoProps): JSX.Element {
     if (value == null) {
       return;
     }
-
     void store.dispatch("editor.setContent", {
       content: value,
       noteId: activeNoteId.current!,
@@ -266,8 +259,6 @@ export function Monaco(props: MonacoProps): JSX.Element {
       if (oldTab != null) {
         const viewState = monacoEditor.current.saveViewState()!;
         const model = monacoEditor.current.getModel()!;
-        console.log("Cache off old tab.");
-        // console.log("New tab. Save model view state!");
         store.dispatch("editor.setModelViewState", {
           noteId: oldTab.note.id,
           modelViewState: {
@@ -275,7 +266,6 @@ export function Monaco(props: MonacoProps): JSX.Element {
             viewState,
           },
         });
-        // props.updateCache(oldTab.note.id, { model, viewState });
       } else {
         store.dispatch("editor.deleteModelViewState", lastActiveTabNoteId);
       }
@@ -297,28 +287,25 @@ export function Monaco(props: MonacoProps): JSX.Element {
 
       let cache = store.cache.modelViewStates[newTab.note.id];
 
-      // let cache = props.modelAndViewStateCache[newTab.note.id];
       // First load, gotta create the model.
       if (cache == null || cache.model.isDisposed()) {
         cache = {
           model: createMarkdownModel(newTab.note.content),
         }!;
 
-        console.log("Generate new model view state");
         store.dispatch("editor.setModelViewState", {
           noteId: newTab.note.id,
           modelViewState: cache,
         });
+      }
 
-        // props.updateCache(newTab.note.id, cache);
-        monacoEditor.current.setModel(cache.model);
+      monacoEditor.current.setModel(cache.model);
 
-        if (cache.viewState) {
-          monacoEditor.current.restoreViewState(cache.viewState);
-        }
-        if (state.focused[0] === Section.Editor) {
-          monacoEditor.current.focus();
-        }
+      if (cache.viewState) {
+        monacoEditor.current.restoreViewState(cache.viewState);
+      }
+      if (state.focused[0] === Section.Editor) {
+        monacoEditor.current.focus();
       }
 
       activeNoteId.current = newTab.note.id;
@@ -340,8 +327,6 @@ export function Monaco(props: MonacoProps): JSX.Element {
       wrapSelections(editor, "_");
     }
   };
-
-  console.log("Render monaco!");
 
   return (
     <StyledEditor
@@ -439,7 +424,6 @@ export const setModelViewState: Listener<"editor.setModelViewState"> = (
     return;
   }
 
-  console.log("editor.setModelViewState()", value);
   ctx.setCache({
     modelViewStates: {
       [value.noteId]: value.modelViewState,

--- a/packages/marqus-desktop/src/renderer/components/Monaco.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Monaco.tsx
@@ -49,13 +49,11 @@ export function Monaco(props: MonacoProps): JSX.Element {
     store.on("editor.boldSelectedText", boldSelectedText);
     store.on("editor.italicSelectedText", italicSelectedText);
     store.on("editor.setModelViewState", setModelViewState);
-    store.on("editor.deleteModelViewState", deleteModelViewState);
 
     return () => {
       store.off("editor.boldSelectedText", boldSelectedText);
       store.off("editor.italicSelectedText", italicSelectedText);
       store.off("editor.setModelViewState", setModelViewState);
-      store.off("editor.deleteModelViewState", deleteModelViewState);
     };
   }, [store]);
 
@@ -196,9 +194,9 @@ export function Monaco(props: MonacoProps): JSX.Element {
 
         // N.B. Disposing monaco editor will also dispose the active model so
         // we remove it from the cache.
-        if (activeNoteId.current != null) {
-          store.dispatch("editor.deleteModelViewState", activeNoteId.current);
-        }
+        // if (activeNoteId.current != null) {
+        //   store.dispatch("editor.deleteModelViewState", activeNoteId.current);
+        // }
       }
 
       if (onChangeSub.current != null) {
@@ -285,13 +283,11 @@ export function Monaco(props: MonacoProps): JSX.Element {
         throw new Error(`Active tab ${editor.activeTabNoteId} was not found.`);
       }
 
-      let cache = store.cache.modelViewStates[newTab.note.id];
+      const cache = store.cache.modelViewStates[newTab.note.id] ?? {};
 
-      // First load, gotta create the model.
-      if (cache == null || cache.model.isDisposed()) {
-        cache = {
-          model: createMarkdownModel(newTab.note.content),
-        }!;
+      // First load, or model was disposed.
+      if (cache.model == null || cache.model.isDisposed()) {
+        cache.model = createMarkdownModel(newTab.note.content);
 
         store.dispatch("editor.setModelViewState", {
           noteId: newTab.note.id,
@@ -427,21 +423,6 @@ export const setModelViewState: Listener<"editor.setModelViewState"> = (
   ctx.setCache({
     modelViewStates: {
       [value.noteId]: value.modelViewState,
-    },
-  });
-};
-
-export const deleteModelViewState: Listener<"editor.deleteModelViewState"> = (
-  { value },
-  ctx,
-) => {
-  if (value == null) {
-    return;
-  }
-
-  ctx.setCache({
-    modelViewStates: {
-      [value]: undefined,
     },
   });
 };

--- a/packages/marqus-desktop/src/renderer/store.ts
+++ b/packages/marqus-desktop/src/renderer/store.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
-import { cloneDeep, isEmpty, pick } from "lodash";
+import { cloneDeep, isEmpty, pick, update } from "lodash";
 import { deepUpdate } from "../shared/deepUpdate";
 import { DeepPartial } from "tsdef";
 import { Note } from "../shared/domain/note";
@@ -87,7 +87,7 @@ export type ListenerLookup = {
 };
 
 export function useStore(initialState: State): Store {
-  const [state, setState] = useState(initialState);
+  const [state, setState] = useState<State>(initialState);
   const cache = useRef<Cache>({ modelViewStates: {} });
   const listeners = useRef<ListenerLookup>({});
   const lastState = useRef(state as Readonly<State>);

--- a/packages/marqus-desktop/src/renderer/store.ts
+++ b/packages/marqus-desktop/src/renderer/store.ts
@@ -30,7 +30,7 @@ export interface Cache {
 }
 
 export type ModelViewState = {
-  model: monaco.editor.ITextModel;
+  model?: monaco.editor.ITextModel;
   viewState?: monaco.editor.ICodeEditorViewState;
 };
 
@@ -107,8 +107,10 @@ export function useStore(initialState: State): Store {
     const newCache = deepUpdate(prevCache, updates, [
       // We don't deep update model or viewstate because they will always be
       // updated all at once.
-      /modelViewStates\.[a-zA-Z0-9]*\..*/,
+      /modelViewStates\.[a-zA-Z0-9]*\.model.*/,
+      /modelViewStates\.[a-zA-Z0-9]*\.viewState.*/,
     ]);
+
     cache.current = newCache;
   }, []);
 

--- a/packages/marqus-desktop/src/renderer/store.ts
+++ b/packages/marqus-desktop/src/renderer/store.ts
@@ -9,9 +9,11 @@ import { UIEventType, UIEventInput } from "../shared/ui/events";
 import { Section, AppState, serializeAppState } from "../shared/ui/app";
 import { log } from "./logger";
 import { arrayify } from "../shared/utils";
+import * as monaco from "monaco-editor";
 
 export interface Store {
-  state: State;
+  state: Readonly<State>;
+  cache: Readonly<Cache>;
   on: On;
   off: Off;
   dispatch: Dispatch;
@@ -21,6 +23,16 @@ export interface State extends AppState {
   notes: Note[];
   shortcuts: Shortcut[];
 }
+
+// TODO: Move to app.ts if we serialize this
+export interface Cache {
+  modelViewStates: Record<string, ModelViewState | undefined>;
+}
+
+export type ModelViewState = {
+  model: monaco.editor.ITextModel;
+  viewState?: monaco.editor.ICodeEditorViewState;
+};
 
 export type Dispatch = <ET extends UIEventType>(
   event: ET,
@@ -48,12 +60,17 @@ export type Focus = (
 ) => void;
 
 export interface StoreContext {
+  setCache: SetCache;
   setUI: SetUI;
   setShortcuts: SetShortcuts;
   setNotes: SetNotes;
   focus: Focus;
   getState(): State;
 }
+
+export type SetCache = (
+  t: Transformer<Cache, DeepPartial<Cache>> | DeepPartial<Cache>,
+) => void;
 
 // UI supports partial updates since it's unlikely we'll want to do full updates
 export type SetUI = (
@@ -71,6 +88,7 @@ export type ListenerLookup = {
 
 export function useStore(initialState: State): Store {
   const [state, setState] = useState(initialState);
+  const cache = useRef<Cache>({ modelViewStates: {} });
   const listeners = useRef<ListenerLookup>({});
   const lastState = useRef(state as Readonly<State>);
 
@@ -78,6 +96,21 @@ export function useStore(initialState: State): Store {
   useLayoutEffect(() => {
     lastState.current = cloneDeep(state);
   }, [state]);
+
+  // Cache is good for storing state that shouldn't trigger a re-render
+  const setCache: SetCache = useCallback(transformer => {
+    const prevCache = cache.current;
+
+    const updates =
+      typeof transformer === "function" ? transformer(prevCache) : transformer;
+
+    const newCache = deepUpdate(prevCache, updates, [
+      // We don't deep update model or viewstate because they will always be
+      // updated all at once.
+      /modelViewStates\.[a-zA-Z0-9]*\..*/,
+    ]);
+    cache.current = newCache;
+  }, []);
 
   const setUI: SetUI = useCallback(transformer => {
     setState(prevState => {
@@ -141,6 +174,7 @@ export function useStore(initialState: State): Store {
 
   const store = useMemo(() => {
     const ctx = {
+      setCache,
       setUI,
       setShortcuts,
       setNotes,
@@ -194,8 +228,8 @@ export function useStore(initialState: State): Store {
       }
     };
 
-    return { state, on, off, dispatch };
-  }, [state, focus, setUI]);
+    return { state, cache: cache.current, on, off, dispatch };
+  }, [state, focus, setUI, setCache]);
 
   return store;
 }

--- a/packages/marqus-desktop/src/shared/deepUpdate.ts
+++ b/packages/marqus-desktop/src/shared/deepUpdate.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable prefer-const */
 /* eslint-disable @typescript-eslint/ban-types */
-import { cloneDeep, get } from "lodash";
+import { get } from "lodash";
 import { DeepPartial } from "tsdef";
 import { isBlank } from "./utils";
 
@@ -84,6 +84,7 @@ function breadthFirst(
       const child = target[k];
 
       let p = path == null ? k : `${path}.${k}`;
+      step(target, k, p);
 
       if (ignorePaths != null && ignorePaths.some(ip => ip.test(p))) {
         continue;
@@ -93,8 +94,6 @@ function breadthFirst(
       if (typeof child === "object" && !Array.isArray(child)) {
         toVisit.push([child, k]);
       }
-
-      step(target, k, p);
     }
 
     // Visit any children we found

--- a/packages/marqus-desktop/src/shared/deepUpdate.ts
+++ b/packages/marqus-desktop/src/shared/deepUpdate.ts
@@ -16,12 +16,10 @@ export function deepUpdate<T extends {}>(
   updates: DeepPartial<T>,
   ignoredPaths?: RegExp[],
 ): T {
-  const newObj = cloneDeep(obj);
-
   breadthFirst(
     updates,
     (update, property, path) => {
-      const existing = get(newObj, path);
+      const existing = get(obj, path);
       /**
        * To prevent from updating children properties from their parents we don't
        * perform updates on objects unless their value has been deleted.
@@ -37,7 +35,7 @@ export function deepUpdate<T extends {}>(
       if (update.hasOwnProperty(property)) {
         const newValue = update[property];
         const parentPath = path.split(".").slice(0, -1).join(".");
-        let parent = isBlank(parentPath) ? newObj : get(newObj, parentPath);
+        let parent = isBlank(parentPath) ? obj : get(obj, parentPath);
 
         // Delete
         if (newValue == null) {
@@ -52,7 +50,7 @@ export function deepUpdate<T extends {}>(
     ignoredPaths,
   );
 
-  return newObj;
+  return obj;
 }
 
 /**

--- a/packages/marqus-desktop/src/shared/ui/events.ts
+++ b/packages/marqus-desktop/src/shared/ui/events.ts
@@ -78,7 +78,6 @@ export interface UIEvents {
     noteId: string;
     modelViewState: ModelViewState;
   };
-  "editor.deleteModelViewState": string;
 
   // Focus Tracker
   "focus.push": Section | Section[];
@@ -157,7 +156,6 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "editor.boldSelectedText",
   "editor.italicSelectedText",
   "editor.setModelViewState",
-  "editor.deleteModelViewState",
 
   // Focus Tracker
   "focus.push",

--- a/packages/marqus-desktop/src/shared/ui/events.ts
+++ b/packages/marqus-desktop/src/shared/ui/events.ts
@@ -1,7 +1,6 @@
 import { Point } from "electron";
-import { ModelViewState } from "../../renderer/store";
 import { NoteSort } from "../domain/note";
-import { Section } from "./app";
+import { ModelViewState, Section } from "./app";
 
 /*
  * Events are defined in shared so we can keep shortcuts and application menus

--- a/packages/marqus-desktop/src/shared/ui/events.ts
+++ b/packages/marqus-desktop/src/shared/ui/events.ts
@@ -1,4 +1,5 @@
 import { Point } from "electron";
+import { ModelViewState } from "../../renderer/store";
 import { NoteSort } from "../domain/note";
 import { Section } from "./app";
 
@@ -73,6 +74,11 @@ export interface UIEvents {
   "editor.updateTabsScroll": number;
   "editor.boldSelectedText": void;
   "editor.italicSelectedText": void;
+  "editor.setModelViewState": {
+    noteId: string;
+    modelViewState: ModelViewState;
+  };
+  "editor.deleteModelViewState": string;
 
   // Focus Tracker
   "focus.push": Section | Section[];
@@ -150,6 +156,8 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "editor.updateTabsScroll",
   "editor.boldSelectedText",
   "editor.italicSelectedText",
+  "editor.setModelViewState",
+  "editor.deleteModelViewState",
 
   // Focus Tracker
   "focus.push",

--- a/packages/marqus-desktop/test/__factories__/state.ts
+++ b/packages/marqus-desktop/test/__factories__/state.ts
@@ -4,7 +4,7 @@ import { DEFAULT_NOTE_SORTING_ALGORITHM } from "../../src/shared/domain/note";
 import { getLatestSchemaVersion } from "../../src/main/schemas/utils";
 import { APP_STATE_SCHEMAS } from "../../src/main/schemas/appState";
 import { cloneDeep, omit } from "lodash";
-import { AppState } from "../../src/shared/ui/app";
+import { AppState, Cache } from "../../src/shared/ui/app";
 
 const latestVersion = getLatestSchemaVersion(APP_STATE_SCHEMAS);
 
@@ -34,4 +34,10 @@ export function createState(partial?: DeepPartial<State>): State {
 export function createAppState(partial?: DeepPartial<AppState>): AppState {
   const state = createState(partial);
   return omit(state, "notes", "shortcuts");
+}
+
+export function createCache(partial?: Partial<Cache>): Cache {
+  return {
+    modelViewStates: partial?.modelViewStates ?? {},
+  };
 }

--- a/packages/marqus-desktop/test/__mocks__/store.ts
+++ b/packages/marqus-desktop/test/__mocks__/store.ts
@@ -11,5 +11,8 @@ export function mockStore(partial?: CreateStore): Store {
     off: partial?.off ?? jest.fn(),
     dispatch: partial?.dispatch ?? jest.fn(),
     state: createState(partial?.state),
+    cache: {
+      modelViewStates: {},
+    },
   };
 }

--- a/packages/marqus-desktop/test/renderer/App.spec.tsx
+++ b/packages/marqus-desktop/test/renderer/App.spec.tsx
@@ -1,14 +1,16 @@
 import { act, fireEvent, render } from "@testing-library/react";
 import { App } from "../../src/renderer/App";
 import { createConfig } from "../__factories__/config";
-import { createState } from "../__factories__/state";
+import { createCache, createState } from "../__factories__/state";
 import React from "react";
 import { log } from "../../src/renderer/logger";
 
 jest.mock("./../../src/renderer/logger");
 
 test("Uncaught errors are logged.", async () => {
-  render(<App state={createState()} config={createConfig()} />);
+  render(
+    <App state={createState()} config={createConfig()} cache={createCache()} />,
+  );
 
   act(() => {
     fireEvent.error(window);

--- a/packages/marqus-desktop/test/renderer/components/Focusable.spec.tsx
+++ b/packages/marqus-desktop/test/renderer/components/Focusable.spec.tsx
@@ -12,6 +12,7 @@ import * as store from "../../../src/renderer/store";
 import { mockStore } from "../../__mocks__/store";
 import { Section } from "../../../src/shared/ui/app";
 import { createConfig } from "../../__factories__/config";
+import { createCache } from "../../__factories__/state";
 
 function init(
   props: FocusableProps,
@@ -26,7 +27,11 @@ test("useFocusTracking detects clicks in focusables", async () => {
   jest.spyOn(store, "useStore").mockImplementation(() => s);
 
   const res = render(
-    <App state={s.state} config={createConfig({ noteDirectory: "foo" })} />,
+    <App
+      state={s.state}
+      config={createConfig({ noteDirectory: "foo" })}
+      cache={createCache()}
+    />,
   );
 
   // Simulate a click within the sidebar search.

--- a/packages/marqus-desktop/test/renderer/components/Monaco.spec.tsx
+++ b/packages/marqus-desktop/test/renderer/components/Monaco.spec.tsx
@@ -27,15 +27,7 @@ test("importAttachments", async () => {
   });
   const config = createConfig();
 
-  const r = render(
-    <Monaco
-      store={store.current}
-      config={config}
-      modelAndViewStateCache={{}}
-      updateCache={jest.fn()}
-      removeCache={jest.fn()}
-    />,
-  );
+  const r = render(<Monaco store={store.current} config={config} />);
   const monacoContainer = r.getByTestId("monaco-container");
 
   const model = {


### PR DESCRIPTION
- `deepUpdate` now handles objects with circular references pointing to parents, and also can ignore specific paths.
- Introduced new `cache` in the front end store that lets us save data without triggering re-renders.
- Reduced number of times we call `setModel()` on Monaco to improve performance.
- Moved Monaco model and view states to live in the store instead of in the `Editor` component.
- View states are saved to file so on the next load we can restore an editor to exactly how the user left it.