### PR TITLE
Populate notes with a header of the note name

### DIFF
--- a/packages/marqus-desktop/src/renderer/components/Editor.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Editor.tsx
@@ -104,6 +104,11 @@ const setContent: Listener<"editor.setContent"> = async ({ value }, ctx) => {
     );
     // Update local cache for renderer
     prev.editor.tabs[index].note.content = content;
+
+    if (prev.editor.tabs[index].isNewNote) {
+      delete prev.editor.tabs[index].isNewNote;
+    }
+
     return {
       editor: {
         tabs: [...prev.editor.tabs],

--- a/packages/marqus-desktop/src/renderer/components/Sidebar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Sidebar.tsx
@@ -484,7 +484,7 @@ export const createNote: Listener<"sidebar.createNote"> = async (ev, ctx) => {
           isEditing: true,
           activeTabNoteId: note.id,
           // Keep in sync with openTab in EditorToolbar.tsx
-          tabs: [...prev.editor.tabs, { note, content: "" }],
+          tabs: [...prev.editor.tabs, { note, content: "", isNewNote: true }],
         },
       }));
     } catch (e) {

--- a/packages/marqus-desktop/src/shared/domain/note.ts
+++ b/packages/marqus-desktop/src/shared/domain/note.ts
@@ -96,7 +96,7 @@ export function createNote(props: Partial<Note> & Pick<Note, "name">): Note {
 
   note.id ??= uuid();
   note.dateCreated ??= new Date();
-  note.content ??= "";
+  note.content ??= `# ${note.name}`;
 
   // Trim out null parent id
   if (note.parent === null) {

--- a/packages/marqus-desktop/src/shared/ui/app.ts
+++ b/packages/marqus-desktop/src/shared/ui/app.ts
@@ -45,6 +45,7 @@ export interface Editor {
 export interface EditorTab {
   note: Note;
   lastActive?: Date;
+  isNewNote?: boolean;
 }
 
 export interface Cache {

--- a/packages/marqus-desktop/src/shared/ui/events.ts
+++ b/packages/marqus-desktop/src/shared/ui/events.ts
@@ -73,6 +73,7 @@ export interface UIEvents {
   "editor.updateTabsScroll": number;
   "editor.boldSelectedText": void;
   "editor.italicSelectedText": void;
+  "editor.selectAllText": { isNewNote?: boolean };
   "editor.setModelViewState": {
     noteId: string;
     modelViewState: ModelViewState;
@@ -154,6 +155,7 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "editor.updateTabsScroll",
   "editor.boldSelectedText",
   "editor.italicSelectedText",
+  "editor.selectAllText",
   "editor.setModelViewState",
 
   // Focus Tracker


### PR DESCRIPTION
- When creating a new note the content will automatically start with a header of the note name.
- The editor will also highlight the text of the header to make this easy to change