### PR TITLE
Prevent selected notes from opening when creating note

### DIFF
--- a/packages/marqus-desktop/src/renderer/App.tsx
+++ b/packages/marqus-desktop/src/renderer/App.tsx
@@ -186,7 +186,7 @@ export async function loadInitialState(
       },
       editor: {
         ...ui.editor,
-        tabs: tabs.map(t => ({ ...t, fromPreviousSession: true })),
+        tabs,
       },
     },
     notes,

--- a/packages/marqus-desktop/src/renderer/components/Sidebar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Sidebar.tsx
@@ -476,17 +476,19 @@ export const createNote: Listener<"sidebar.createNote"> = async (ev, ctx) => {
       });
 
       ctx.focus([Section.Editor], { overwrite: true });
-      ctx.setUI(prev => ({
-        sidebar: {
-          selected: [note.id],
-        },
-        editor: {
-          isEditing: true,
-          activeTabNoteId: note.id,
-          // Keep in sync with openTab in EditorToolbar.tsx
-          tabs: [...prev.editor.tabs, { note, content: "" }],
-        },
-      }));
+      ctx.setUI(prev => {
+        return {
+          sidebar: {
+            selected: [note.id],
+          },
+          editor: {
+            isEditing: true,
+            activeTabNoteId: note.id,
+            // Keep in sync with openTab in EditorToolbar.tsx
+            tabs: [...prev.editor.tabs, { note, content: "" }],
+          },
+        };
+      });
     } catch (e) {
       await promptError((e as Error).message);
     }

--- a/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
+++ b/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
@@ -175,6 +175,9 @@ export function SidebarInput(props: SidebarInputProps): JSX.Element {
   };
 
   const keyDown = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+    // Swallow event to avoid triggering shortcuts
+    ev.stopPropagation();
+
     const key = parseKeyCode(ev.code);
     switch (key) {
       case KeyCode.Enter:
@@ -182,9 +185,6 @@ export function SidebarInput(props: SidebarInputProps): JSX.Element {
       case KeyCode.Escape:
         return cancel();
     }
-
-    // Swallow keyboard events to prevent shortcuts from triggering.
-    ev.stopPropagation();
   };
 
   // On first render, scroll the input into view.


### PR DESCRIPTION
There was a bug where the when pressing enter while the sidebar input is focused it'll trigger the open selected note shortcut to fire.

This was because we weren't stopping propagation of the event properly.