### PR TITLE
Remove auto reload on error

### DIFF
--- a/packages/marqus-desktop/src/main/index.ts
+++ b/packages/marqus-desktop/src/main/index.ts
@@ -1,7 +1,6 @@
 import { app, BrowserWindow, ipcMain, session } from "electron";
 import { getProcessType, isDevelopment, isTest } from "../shared/env";
-import { sleep } from "../shared/utils";
-import { initPlugins, IpcMainTS, IPC_PLUGINS, OnDispose } from "./ipc";
+import { initPlugins, IpcMainTS, IPC_PLUGINS } from "./ipc";
 import { getConfig } from "./ipc/plugins/config";
 import { getFileTransport, logger } from "./logger";
 import { setCspHeader } from "./utils";

--- a/packages/marqus-desktop/src/renderer/App.tsx
+++ b/packages/marqus-desktop/src/renderer/App.tsx
@@ -90,13 +90,6 @@ export function App(props: AppProps): JSX.Element {
 
     const onError = async (err: ErrorEvent) => {
       await log.error("Uncaught Error:", err.error);
-
-      // N.B. We add a delay to slow down refreshes in case an infinite loop was
-      // somehow triggered.
-      setTimeout(async () => {
-        await log.info("Attempting to recover from error. Reloading!");
-        window.location.reload();
-      }, 10000);
     };
     window.addEventListener("error", onError);
 


### PR DESCRIPTION
- Removed auto reload because it was getting hard to debug errors when the error message vanishes too fast.