### PR TITLE
Add ability to pin tabs to they are always first in the toolbar

### DIFF
--- a/packages/marqus-desktop/src/main/ipc/plugins/app.ts
+++ b/packages/marqus-desktop/src/main/ipc/plugins/app.ts
@@ -22,10 +22,11 @@ import { IpcPlugin } from "..";
 import * as fs from "fs";
 import { Config } from "../../../shared/domain/config";
 import { getConfigDirectory } from "./config";
+import { getLatestSchemaVersion } from "../../schemas/utils";
 
 export const APP_STATE_FILE = "appState.json";
 export const APP_STATE_DEFAULTS = {
-  version: 2,
+  version: getLatestSchemaVersion(APP_STATE_SCHEMAS),
   sidebar: {
     scroll: 0,
     sort: NoteSort.Alphanumeric,

--- a/packages/marqus-desktop/src/main/schemas/appState/3_addIsPinned.ts
+++ b/packages/marqus-desktop/src/main/schemas/appState/3_addIsPinned.ts
@@ -1,10 +1,10 @@
 import { z } from "zod";
-import { AppStateV1 } from "./1_initialDefinition";
 import { ModelViewState, Section } from "../../../shared/ui/app";
 import { DATE_OR_STRING_SCHEMA, PX_REGEX } from "../../../shared/domain";
 import { NoteSort } from "../../../shared/domain/note";
+import { AppStateV2 } from "./2_addViewState";
 
-export interface AppStateV2 {
+export interface AppStateV3 {
   version: number;
   sidebar: Sidebar;
   editor: Editor;
@@ -34,19 +34,20 @@ interface EditorTab {
   noteContent?: string;
   lastActive?: Date | string;
   viewState?: ModelViewState["viewState"];
+  isPinned?: boolean;
 }
 
-export const appStateV2 = z.preprocess(
+export const appStateV3 = z.preprocess(
   obj => {
-    const state = obj as AppStateV1 | AppStateV2;
-    if (state.version === 1) {
-      state.version = 2;
+    const state = obj as AppStateV2 | AppStateV3;
+    if (state.version === 2) {
+      state.version = 3;
     }
 
     return state;
   },
   z.object({
-    version: z.literal(2),
+    version: z.literal(3),
     sidebar: z.object({
       width: z.string().regex(PX_REGEX),
       scroll: z.number(),
@@ -65,6 +66,7 @@ export const appStateV2 = z.preprocess(
           // Intentionally omitted noteContent
           lastActive: DATE_OR_STRING_SCHEMA.optional(),
           viewState: z.any().optional(),
+          isPinned: z.boolean().optional(),
         }),
       ),
       tabsScroll: z.number(),

--- a/packages/marqus-desktop/src/main/schemas/appState/index.ts
+++ b/packages/marqus-desktop/src/main/schemas/appState/index.ts
@@ -1,7 +1,9 @@
 import { appStateV1 } from "./1_initialDefinition";
 import { appStateV2 } from "./2_addViewState";
+import { appStateV3 } from "./3_addIsPinned";
 
 export const APP_STATE_SCHEMAS = {
   1: appStateV1,
   2: appStateV2,
+  3: appStateV3,
 };

--- a/packages/marqus-desktop/src/renderer/App.tsx
+++ b/packages/marqus-desktop/src/renderer/App.tsx
@@ -161,6 +161,7 @@ export async function loadInitialState(
     .map(t => ({
       note: getNoteById(notes, t.noteId, false),
       lastActive: t.lastActive,
+      isPinned: t.isPinned,
     }))
     .filter(t => t.note != null) as EditorTab[];
 

--- a/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
@@ -1,4 +1,8 @@
-import { faFile, faTimes } from "@fortawesome/free-solid-svg-icons";
+import {
+  faFile,
+  faTimes,
+  faThumbtack,
+} from "@fortawesome/free-solid-svg-icons";
 import React, { useEffect, useRef } from "react";
 import styled from "styled-components";
 import { m0, mr2, p2, px2, THEME } from "../css";
@@ -10,12 +14,14 @@ export interface EditorTabProps {
   notePath: string;
   noteName: string;
   active?: boolean;
+  isPinned?: boolean;
   onClick: (noteId: string) => void;
   onClose: (noteId: string) => void;
+  onUnpin: (noteId: string) => void;
 }
 
 export function EditorTab(props: EditorTabProps): JSX.Element {
-  const { noteId, noteName, notePath, active } = props;
+  const { noteId, noteName, notePath, active, isPinned } = props;
 
   const wrapper = useRef(null! as HTMLAnchorElement);
   useEffect(() => {
@@ -26,11 +32,37 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
     }
   }, [active]);
 
-  const onDeleteClick = (ev: React.MouseEvent<HTMLElement>) => {
-    // Need to stop prop otherwise it'll trigger onClick of tab.
-    ev.stopPropagation();
-    props.onClose(noteId);
-  };
+  let action;
+  if (isPinned) {
+    const onUnpinClick = (ev: React.MouseEvent<HTMLElement>) => {
+      // Need to stop prop otherwise it'll trigger onClick of tab.
+      ev.stopPropagation();
+      props.onUnpin(noteId);
+    };
+
+    action = (
+      <StyledPinnedIcon
+        icon={faThumbtack}
+        title={`Unpin ${noteName}`}
+        onClick={onUnpinClick}
+      />
+    );
+  } else {
+    const onDeleteClick = (ev: React.MouseEvent<HTMLElement>) => {
+      // Need to stop prop otherwise it'll trigger onClick of tab.
+      ev.stopPropagation();
+      props.onClose(noteId);
+    };
+
+    action = (
+      <StyledDeleteIcon
+        icon={faTimes}
+        onClick={onDeleteClick}
+        className="delete"
+        title={`Close ${noteName}`}
+      />
+    );
+  }
 
   return (
     <StyledTab
@@ -45,12 +77,7 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
         <StyledNoteIcon icon={faFile} size="lg" />
         <StyledText>{noteName}</StyledText>
       </FlexRow>
-      <StyledDelete
-        icon={faTimes}
-        onClick={onDeleteClick}
-        className="delete"
-        title={`Close ${noteName}`}
-      />
+      {action}
     </StyledTab>
   );
 }
@@ -101,7 +128,7 @@ const StyledText = styled.span`
   min-width: 0;
 `;
 
-const StyledDelete = styled(Icon)`
+const StyledDeleteIcon = styled(Icon)`
   border-radius: 0.4rem;
   ${p2}
   ${m0}
@@ -110,6 +137,19 @@ const StyledDelete = styled(Icon)`
   &:hover {
     cursor: pointer;
     color: ${THEME.editor.toolbar.deleteHoverColor};
+    background-color: ${THEME.editor.toolbar.deleteHoverBackground};
+  }
+`;
+
+const StyledPinnedIcon = styled(Icon)`
+  border-radius: 0.4rem;
+  ${p2}
+  ${m0}
+  color: ${THEME.editor.toolbar.deleteColor};
+
+  &:hover {
+    cursor: pointer;
+    color: ${THEME.editor.toolbar.unpinHoverColor};
     background-color: ${THEME.editor.toolbar.deleteHoverBackground};
   }
 `;

--- a/packages/marqus-desktop/src/renderer/css.ts
+++ b/packages/marqus-desktop/src/renderer/css.ts
@@ -41,6 +41,8 @@ export const THEME = {
       deleteColor: OpenColor.gray[6],
       deleteHoverColor: OpenColor.red[7],
       deleteHoverBackground: OpenColor.gray[3],
+      unpinHoverColor: OpenColor.gray[8],
+      unpinHoverBackground: OpenColor.gray[3],
       scrollbarColor: OpenColor.gray[5],
     },
   },

--- a/packages/marqus-desktop/src/renderer/menus/contextMenu.ts
+++ b/packages/marqus-desktop/src/renderer/menus/contextMenu.ts
@@ -126,6 +126,30 @@ export function useContextMenu(store: Store, config: Config): void {
           const tabNoteId = getEditorTabAttribute(ev.target as HTMLElement);
 
           if (tabNoteId != null) {
+            const tab = state.editor.tabs.find(t => t.note.id === tabNoteId)!;
+
+            if (tab.isPinned) {
+              items.push({
+                label: "Unpin tab",
+                type: "normal",
+                event: "editor.unpinTab",
+                eventInput: tabNoteId,
+                shortcut: shortcutLabels["editor.unpinTab"],
+              });
+            } else {
+              items.push({
+                label: "Pin tab",
+                type: "normal",
+                event: "editor.pinTab",
+                eventInput: tabNoteId,
+                shortcut: shortcutLabels["editor.pinTab"],
+              });
+            }
+
+            items.push({
+              type: "separator",
+            });
+
             items.push({
               label: "Close",
               type: "normal",

--- a/packages/marqus-desktop/src/shared/ui/app.ts
+++ b/packages/marqus-desktop/src/shared/ui/app.ts
@@ -46,6 +46,7 @@ export interface EditorTab {
   note: Note;
   lastActive?: Date;
   isNewNote?: boolean;
+  isPinned?: boolean;
 }
 
 export interface Cache {
@@ -124,6 +125,7 @@ export interface SerializedEditorTab {
   noteId: string;
   lastActive?: Date;
   viewState?: monaco.editor.ICodeEditorViewState;
+  isPinned?: boolean;
 }
 
 export function serializeAppState(
@@ -146,6 +148,7 @@ export function serializeAppState(
         noteId: t.note.id,
         lastActive: t.lastActive,
         viewState: cache?.modelViewStates[t.note.id]?.viewState,
+        isPinned: t.isPinned,
       })),
     },
   };

--- a/packages/marqus-desktop/src/shared/ui/events.ts
+++ b/packages/marqus-desktop/src/shared/ui/events.ts
@@ -62,6 +62,8 @@ export interface UIEvents {
   "editor.openTab":
     | { note: string | string[]; active?: string; focus?: boolean }
     | undefined;
+  "editor.pinTab": string;
+  "editor.unpinTab": string;
   "editor.closeActiveTab": string;
   "editor.closeTab": string;
   "editor.closeAllTabs": void;
@@ -144,6 +146,8 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "editor.setContent",
   "editor.updateScroll",
   "editor.openTab",
+  "editor.pinTab",
+  "editor.unpinTab",
   "editor.closeTab",
   "editor.closeActiveTab",
   "editor.closeAllTabs",


### PR DESCRIPTION
Notes can now be pinned so they stay at the start of the editor toolbar.
