### PR TITLE
Show note / tab being dragged

### DIFF
--- a/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
@@ -16,7 +16,7 @@ import styled from "styled-components";
 import { Section } from "../../shared/ui/app";
 import { m0, mr2, p2, px2, THEME } from "../css";
 import { MouseDrag, useMouseDrag } from "../io/mouse";
-import { getClosestAttribute } from "../utils/dom";
+import { getClosestAttribute, getOffsetRelativeTo } from "../utils/dom";
 import { wasInsideFocusable } from "./shared/Focusable";
 import { Icon } from "./shared/Icon";
 
@@ -105,7 +105,7 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
           el.style.top = `${mouseY - offsetY - 8}px`;
         }
       } else if (drag.state === "dragStarted") {
-        offset.current = [drag.event.offsetX, drag.event.offsetY];
+        offset.current = getOffsetRelativeTo(drag.event, wrapper.current);
 
         setCursorEl(
           <CursorFollower ref={cursorElRef}>
@@ -209,11 +209,6 @@ const StyledTab = styled.a<{ active?: boolean }>`
     .delete {
       display: block;
     }
-  }
-
-  // We need offsetX, offsetY to always for the tab container.
-  * {
-    pointer-events: none;
   }
 `;
 

--- a/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
@@ -84,7 +84,7 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
   }
 
   const [cursorEl, setCursorEl] = useState<JSX.Element | undefined>();
-  const cursorRef = useRef<HTMLDivElement | null>(null);
+  const cursorElRef = useRef<HTMLDivElement | null>(null);
   const onDrag = useCallback(
     (drag: MouseDrag | null) => {
       if (!drag || drag.state === "dragCancelled") {
@@ -94,14 +94,14 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
 
       const { clientX: mouseX, clientY: mouseY } = drag.event;
       if (drag.state === "dragging") {
-        const el = cursorRef.current;
+        const el = cursorElRef.current;
         if (el) {
           el.style.left = `${mouseX}px`;
           el.style.top = `${mouseY}px`;
         }
       } else if (drag.state === "dragStarted") {
         setCursorEl(
-          <CursorFollower ref={cursorRef}>
+          <CursorFollower ref={cursorElRef}>
             <StyledTab active={active}>
               <FlexRow>
                 <StyledNoteIcon icon={faFile} size="lg" />

--- a/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
@@ -16,7 +16,7 @@ import styled from "styled-components";
 import { Section } from "../../shared/ui/app";
 import { m0, mr2, p2, px2, THEME } from "../css";
 import { MouseDrag, useMouseDrag } from "../io/mouse";
-import { getClosestAttribute, getOffsetRelativeTo } from "../utils/dom";
+import { getClosestAttribute } from "../utils/dom";
 import { wasInsideFocusable } from "./shared/Focusable";
 import { Icon } from "./shared/Icon";
 
@@ -83,7 +83,6 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
     );
   }
 
-  const offset = useRef<[number, number]>();
   const [cursorEl, setCursorEl] = useState<JSX.Element | undefined>();
   const cursorElRef = useRef<HTMLDivElement | null>(null);
   const onDrag = useCallback(
@@ -98,15 +97,13 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
         const el = cursorElRef.current;
 
         if (el) {
-          const [offsetX, offsetY] = offset.current ?? [0, 0];
+          const [offsetX, offsetY] = drag.initialOffset;
 
           el.style.left = `${mouseX - offsetX}px`;
           // Keep in sync with margin-top of StyledTab
           el.style.top = `${mouseY - offsetY - 8}px`;
         }
       } else if (drag.state === "dragStarted") {
-        offset.current = getOffsetRelativeTo(drag.event, wrapper.current);
-
         setCursorEl(
           <CursorFollower ref={cursorElRef}>
             <StyledTab active={active}>

--- a/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
@@ -83,6 +83,7 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
     );
   }
 
+  const offset = useRef<[number, number]>();
   const [cursorEl, setCursorEl] = useState<JSX.Element | undefined>();
   const cursorElRef = useRef<HTMLDivElement | null>(null);
   const onDrag = useCallback(
@@ -95,11 +96,17 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
       const { clientX: mouseX, clientY: mouseY } = drag.event;
       if (drag.state === "dragging") {
         const el = cursorElRef.current;
+
         if (el) {
-          el.style.left = `${mouseX}px`;
-          el.style.top = `${mouseY}px`;
+          const [offsetX, offsetY] = offset.current ?? [0, 0];
+
+          el.style.left = `${mouseX - offsetX}px`;
+          // Keep in sync with margin-top of StyledTab
+          el.style.top = `${mouseY - offsetY - 8}px`;
         }
       } else if (drag.state === "dragStarted") {
+        offset.current = [drag.event.offsetX, drag.event.offsetY];
+
         setCursorEl(
           <CursorFollower ref={cursorElRef}>
             <StyledTab active={active}>
@@ -133,9 +140,7 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
     [noteId, props, active, noteName],
   );
 
-  useMouseDrag(wrapper, onDrag, {
-    cursor: "grabbing",
-  });
+  useMouseDrag(wrapper, onDrag, { cursor: "grabbing" });
 
   return (
     <>
@@ -143,7 +148,7 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
         {...{ [EDITOR_TAB_ATTRIBUTE]: noteId }}
         onClick={() => props.onClick(noteId)}
       >
-        <StyledTab ref={wrapper} key={noteId} title={notePath} active={active}>
+        <StyledTab ref={wrapper} title={notePath} active={active}>
           <FlexRow>
             <StyledNoteIcon icon={faFile} size="lg" />
             <StyledText>{noteName}</StyledText>
@@ -204,6 +209,11 @@ const StyledTab = styled.a<{ active?: boolean }>`
     .delete {
       display: block;
     }
+  }
+
+  // We need offsetX, offsetY to always for the tab container.
+  * {
+    pointer-events: none;
   }
 `;
 

--- a/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
+++ b/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
@@ -11,7 +11,7 @@ import { Icon } from "./shared/Icon";
 import { MouseDrag, useMouseDrag } from "../io/mouse";
 import { Section } from "../../shared/ui/app";
 import { partial } from "lodash";
-import { getClosestAttribute, getOffsetRelativeTo } from "../utils/dom";
+import { getClosestAttribute } from "../utils/dom";
 import { createPortal } from "react-dom";
 
 export const SIDEBAR_MENU_ATTRIBUTE = "data-nav-menu";
@@ -37,7 +37,7 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
   const { title, value, icon, isSelected, onClick, store } = props;
   const { state } = store;
 
-  const iconOffset = icon ? 0 : 8;
+  const iconOffset = icon ? 0 : 4;
   const paddingLeft = `${props.depth * SIDEBAR_MENU_INDENT + iconOffset}px`;
 
   let backgroundColor = THEME.sidebar.background;

--- a/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
+++ b/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
@@ -11,7 +11,7 @@ import { Icon } from "./shared/Icon";
 import { MouseDrag, useMouseDrag } from "../io/mouse";
 import { Section } from "../../shared/ui/app";
 import { partial } from "lodash";
-import { getClosestAttribute } from "../utils/dom";
+import { getClosestAttribute, getOffsetRelativeTo } from "../utils/dom";
 import { createPortal } from "react-dom";
 
 export const SIDEBAR_MENU_ATTRIBUTE = "data-nav-menu";
@@ -45,8 +45,9 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
     backgroundColor = THEME.sidebar.selected;
   }
 
-  const menuRef = useRef<HTMLAnchorElement>(null);
+  const menuRef = useRef<HTMLAnchorElement>(null!);
 
+  const offset = useRef<[number, number]>();
   const [cursorEl, setCursorEl] = useState<JSX.Element | undefined>();
   const cursorElRef = useRef<HTMLDivElement | null>(null);
   const { width } = store.state.sidebar;
@@ -61,10 +62,14 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
       if (drag.state === "dragging") {
         const el = cursorElRef.current;
         if (el) {
-          el.style.left = `${mouseX}px`;
-          el.style.top = `${mouseY}px`;
+          const [offsetX, offsetY] = offset.current ?? [0, 0];
+
+          el.style.left = `${mouseX - offsetX}px`;
+          el.style.top = `${mouseY - offsetY}px`;
         }
       } else if (drag.state === "dragStarted") {
+        offset.current = getOffsetRelativeTo(drag.event, menuRef.current);
+
         setCursorEl(
           <CursorFollower ref={cursorElRef}>
             <StyledMenu style={{ paddingLeft, backgroundColor, width }}>

--- a/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
+++ b/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
@@ -68,8 +68,8 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
         }
       } else if (drag.state === "dragStarted") {
         setCursorEl(
-          <CursorFollower ref={cursorElRef}>
-            <StyledMenu style={{ paddingLeft, backgroundColor, width }}>
+          <CursorFollower ref={cursorElRef} style={{ width }}>
+            <StyledMenu style={{ paddingLeft, backgroundColor }}>
               {icon && (
                 <StyledMenuIcon
                   icon={icon}

--- a/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
+++ b/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
@@ -47,7 +47,6 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
 
   const menuRef = useRef<HTMLAnchorElement>(null!);
 
-  const offset = useRef<[number, number]>();
   const [cursorEl, setCursorEl] = useState<JSX.Element | undefined>();
   const cursorElRef = useRef<HTMLDivElement | null>(null);
   const { width } = store.state.sidebar;
@@ -62,14 +61,12 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
       if (drag.state === "dragging") {
         const el = cursorElRef.current;
         if (el) {
-          const [offsetX, offsetY] = offset.current ?? [0, 0];
+          const [offsetX, offsetY] = drag.initialOffset;
 
           el.style.left = `${mouseX - offsetX}px`;
           el.style.top = `${mouseY - offsetY}px`;
         }
       } else if (drag.state === "dragStarted") {
-        offset.current = getOffsetRelativeTo(drag.event, menuRef.current);
-
         setCursorEl(
           <CursorFollower ref={cursorElRef}>
             <StyledMenu style={{ paddingLeft, backgroundColor, width }}>

--- a/packages/marqus-desktop/src/renderer/io/mouse.ts
+++ b/packages/marqus-desktop/src/renderer/io/mouse.ts
@@ -90,14 +90,6 @@ export function useMouseDrag(
         return;
       }
 
-      if (
-        drag != null &&
-        drag.state !== "dragCancelled" &&
-        drag.state !== "dragEnded"
-      ) {
-        throw new Error(`Mouse is already dragging. Can't restart.`);
-      }
-
       const newDrag: MouseDrag = {
         state: "dragStarted",
         event,

--- a/packages/marqus-desktop/src/renderer/io/mouse.ts
+++ b/packages/marqus-desktop/src/renderer/io/mouse.ts
@@ -1,5 +1,6 @@
-import { RefObject, useEffect, useState } from "react";
+import { RefObject, useEffect, useRef, useState } from "react";
 import { parseKeyCode, KeyCode } from "../../shared/io/keyCode";
+import { getOffsetRelativeTo } from "../utils/dom";
 
 export const DEFAULT_CURSOR = "auto";
 
@@ -61,6 +62,7 @@ export type MouseDrag =
   | {
       event: MouseEvent;
       state: Exclude<DragState, "dragCancelled">;
+      initialOffset: [number, number];
     }
   | {
       state: "dragCancelled";
@@ -73,7 +75,7 @@ export type DragState =
   | "dragCancelled";
 
 export function useMouseDrag(
-  ref: RefObject<HTMLElement | Window | null>,
+  ref: RefObject<HTMLElement | null>,
   callback: (drag: MouseDrag | null) => void,
   opts?: { cursor: Cursor; disabled?: boolean },
 ): void {
@@ -93,6 +95,7 @@ export function useMouseDrag(
       const newDrag: MouseDrag = {
         state: "dragStarted",
         event,
+        initialOffset: getOffsetRelativeTo(event, el),
       };
       setDrag(newDrag);
     };
@@ -120,6 +123,7 @@ export function useMouseDrag(
       const newDrag: MouseDrag = {
         state: "dragging",
         event,
+        initialOffset: drag.initialOffset,
       };
       setDrag(newDrag);
       callback(newDrag);
@@ -143,6 +147,7 @@ export function useMouseDrag(
       const newDrag: MouseDrag = {
         state: "dragEnded",
         event,
+        initialOffset: drag.initialOffset,
       };
       setDrag(newDrag);
       if (opts?.cursor) {

--- a/packages/marqus-desktop/src/renderer/menus/contextMenu.ts
+++ b/packages/marqus-desktop/src/renderer/menus/contextMenu.ts
@@ -223,7 +223,15 @@ export function useContextMenu(store: Store, config: Config): void {
     return () => {
       window.removeEventListener("contextmenu", showMenu);
     };
-  }, [shortcutLabels, store, state.notes, state.sidebar.sort, config]);
+  }, [
+    shortcutLabels,
+    store,
+    state.notes,
+    state.sidebar.sort,
+    config,
+    state.editor.isEditing,
+    state.editor.tabs,
+  ]);
 
   useEffect(() => {
     const onClick = async (ev: CustomEvent) => {

--- a/packages/marqus-desktop/src/renderer/utils/dom.ts
+++ b/packages/marqus-desktop/src/renderer/utils/dom.ts
@@ -9,3 +9,18 @@ export function getClosestAttribute(
 
   return null;
 }
+
+export function getOffsetRelativeTo(
+  event: MouseEvent,
+  parentElement: HTMLElement,
+): [number, number] {
+  const { offsetX, offsetY } = event;
+
+  const parentRect = parentElement.getBoundingClientRect();
+  const targetRect = (event.target as HTMLElement).getBoundingClientRect();
+
+  return [
+    targetRect.left - parentRect.left + offsetX,
+    targetRect.top - parentRect.top + offsetY,
+  ];
+}


### PR DESCRIPTION
Notes being dragged by the cursor to change their parent are now shown following the cursor.

Tabs has also been dialed in to look seamless when dragging.

![demo](https://user-images.githubusercontent.com/25796180/230160465-edceb1ef-993d-4f46-9957-bf9c0b0bc0ee.gif)
