### PR TITLE
Prevent last state going stale

### DIFF
--- a/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
@@ -512,16 +512,7 @@ export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
     ctx.focus([Section.Editor], { overwrite: true });
   }
 
-  // Filter out any closed tabs that have been reopened.
-  ctx.setCache(prev => {
-    const closedTabs = prev.closedTabs.filter(
-      ct => !tabs.some(t => t.note.id === ct.noteId),
-    );
-
-    return {
-      closedTabs,
-    };
-  });
+  cleanupClosedTabsCache(ctx);
 };
 
 export const reopenClosedTab: Listener<"editor.reopenClosedTab"> = async (
@@ -719,5 +710,20 @@ export function setActiveTab(
       expanded,
       selected: [activeTabNoteId],
     },
+  });
+}
+
+export function cleanupClosedTabsCache(ctx: StoreContext): void {
+  const { tabs } = ctx.getState().editor;
+
+  // Filter out any closed tabs that have been reopened.
+  ctx.setCache(prev => {
+    const closedTabs = prev.closedTabs.filter(
+      ct => !tabs.some(t => t.note.id === ct.noteId),
+    );
+
+    return {
+      closedTabs,
+    };
   });
 }

--- a/packages/marqus-desktop/src/renderer/components/Sidebar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Sidebar.tsx
@@ -28,6 +28,7 @@ import { EditorTab } from "../../shared/ui/app";
 import { SidebarNewNoteButton } from "./SidebarNewNoteButton";
 import { Section } from "../../shared/ui/app";
 import { deleteNoteIfConfirmed } from "../utils/deleteNoteIfConfirmed";
+import { cleanupClosedTabsCache } from "./EditorToolbar";
 
 const EXPANDED_ICON = faChevronDown;
 const COLLAPSED_ICON = faChevronRight;
@@ -764,16 +765,7 @@ export const openSelectedNotes: Listener<"sidebar.openSelectedNotes"> = async (
     },
   }));
 
-  // Filter out any closed tabs that have been reopened.
-  ctx.setCache(prev => {
-    const closedTabs = prev.closedTabs.filter(
-      ct => !tabs.some(t => t.note.id === ct.noteId),
-    );
-
-    return {
-      closedTabs,
-    };
-  });
+  cleanupClosedTabsCache(ctx);
 };
 
 function toggleExpanded(ctx: StoreContext, noteId: string): void {

--- a/packages/marqus-desktop/src/renderer/store.ts
+++ b/packages/marqus-desktop/src/renderer/store.ts
@@ -83,12 +83,7 @@ export function useStore(initialState: State, initialCache?: Cache): Store {
     initialCache ?? { modelViewStates: {}, closedTabs: [] },
   );
   const listeners = useRef<ListenerLookup>({});
-  const lastState = useRef(state as Readonly<State>);
-
-  // We need to run these first
-  useLayoutEffect(() => {
-    lastState.current = cloneDeep(state);
-  }, [state]);
+  const lastState = useRef(state);
 
   // Cache is good for storing state that shouldn't trigger a re-render
   const setCache: SetCache = useCallback(transformer => {
@@ -125,6 +120,12 @@ export function useStore(initialState: State, initialCache?: Cache): Store {
         "app.saveAppState",
         serializeAppState(newUI, cache.current),
       );
+
+      lastState.current = {
+        ...lastState.current,
+        ...newUI,
+      };
+
       return newState;
     });
   }, []);
@@ -135,16 +136,28 @@ export function useStore(initialState: State, initialCache?: Cache): Store {
    */
 
   const setShortcuts: SetShortcuts = transformer => {
-    setState(prevState => ({
-      ...prevState,
-      shortcuts: transformer(prevState.shortcuts),
-    }));
+    setState(prevState => {
+      const shortcuts = transformer(prevState.shortcuts);
+
+      lastState.current.shortcuts = shortcuts;
+
+      return {
+        ...prevState,
+        shortcuts,
+      };
+    });
   };
   const setNotes: SetNotes = transformer => {
-    setState(prevState => ({
-      ...prevState,
-      notes: transformer(prevState.notes),
-    }));
+    setState(prevState => {
+      const notes = transformer(prevState.notes);
+
+      lastState.current.notes = notes;
+
+      return {
+        ...prevState,
+        notes,
+      };
+    });
   };
 
   const focus: Focus = useCallback(
@@ -177,7 +190,7 @@ export function useStore(initialState: State, initialCache?: Cache): Store {
       setShortcuts,
       setNotes,
       focus,
-      getState: () => lastState.current,
+      getState: () => cloneDeep(lastState.current),
       getCache: () => cloneDeep(cache.current),
     };
 

--- a/packages/marqus-desktop/src/renderer/store.ts
+++ b/packages/marqus-desktop/src/renderer/store.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useCallback, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useMemo, useRef, useState } from "react";
 import { cloneDeep, isEmpty, pick } from "lodash";
 import { deepUpdate } from "../shared/deepUpdate";
 import { DeepPartial } from "tsdef";


### PR DESCRIPTION
`ctx.getState()` was returning stale data because the `lastState` ref in the store hook wasn't refreshing until a subsequent render.

To get around this we update the `lastState` ref immediately and no longer rely on updating it in `useLayoutEffect` in the next render.