### PR TITLE
Add preview tabs

### DIFF
--- a/packages/marqus-desktop/src/main/index.ts
+++ b/packages/marqus-desktop/src/main/index.ts
@@ -129,8 +129,7 @@ export async function main(): Promise<void> {
       app.on("ready", createWindow);
     }
   } catch (err) {
-    logger.error("Error: Failed to initialize app.");
-    logger.error(err);
+    logger.error("Error: Failed to initialize app.", err);
 
     mainWindow.webContents.openDevTools();
   }

--- a/packages/marqus-desktop/src/main/schemas/appState/4_addIsPreview.ts
+++ b/packages/marqus-desktop/src/main/schemas/appState/4_addIsPreview.ts
@@ -1,0 +1,79 @@
+import { z } from "zod";
+import { ModelViewState, Section } from "../../../shared/ui/app";
+import { DATE_OR_STRING_SCHEMA, PX_REGEX } from "../../../shared/domain";
+import { NoteSort } from "../../../shared/domain/note";
+import { AppStateV3 } from "./3_addIsPinned";
+
+export interface AppStateV4 {
+  version: number;
+  sidebar: Sidebar;
+  editor: Editor;
+  focused: Section[];
+}
+
+interface Sidebar {
+  searchString?: string;
+  hidden?: boolean;
+  width: string;
+  scroll: number;
+  selected?: string[];
+  expanded?: string[];
+  sort: NoteSort;
+}
+
+interface Editor {
+  isEditing: boolean;
+  scroll: number;
+  tabs: EditorTab[];
+  tabsScroll: number;
+  activeTabNoteId?: string;
+}
+
+interface EditorTab {
+  noteId: string;
+  noteContent?: string;
+  lastActive?: Date | string;
+  viewState?: ModelViewState["viewState"];
+  isPinned?: boolean;
+  isPreview?: boolean;
+}
+
+export const appStateV4 = z.preprocess(
+  obj => {
+    const state = obj as AppStateV3 | AppStateV4;
+    if (state.version === 3) {
+      state.version = 4;
+    }
+
+    return state;
+  },
+  z.object({
+    version: z.literal(4),
+    sidebar: z.object({
+      width: z.string().regex(PX_REGEX),
+      scroll: z.number(),
+      hidden: z.boolean().optional(),
+      selected: z.array(z.string()).optional(),
+      expanded: z.array(z.string()).optional(),
+      sort: z.nativeEnum(NoteSort),
+      searchString: z.string().optional(),
+    }),
+    editor: z.object({
+      isEditing: z.boolean(),
+      scroll: z.number(),
+      tabs: z.array(
+        z.object({
+          noteId: z.string(),
+          // Intentionally omitted noteContent
+          lastActive: DATE_OR_STRING_SCHEMA.optional(),
+          viewState: z.any().optional(),
+          isPinned: z.boolean().optional(),
+          isPreview: z.boolean().optional(),
+        }),
+      ),
+      tabsScroll: z.number(),
+      activeTabNoteId: z.string().optional(),
+    }),
+    focused: z.array(z.nativeEnum(Section)),
+  }),
+);

--- a/packages/marqus-desktop/src/main/schemas/appState/index.ts
+++ b/packages/marqus-desktop/src/main/schemas/appState/index.ts
@@ -1,9 +1,11 @@
 import { appStateV1 } from "./1_initialDefinition";
 import { appStateV2 } from "./2_addViewState";
 import { appStateV3 } from "./3_addIsPinned";
+import { appStateV4 } from "./4_addIsPreview";
 
 export const APP_STATE_SCHEMAS = {
   1: appStateV1,
   2: appStateV2,
   3: appStateV3,
+  4: appStateV4,
 };

--- a/packages/marqus-desktop/src/renderer/App.tsx
+++ b/packages/marqus-desktop/src/renderer/App.tsx
@@ -162,6 +162,7 @@ export async function loadInitialState(
       note: getNoteById(notes, t.noteId, false),
       lastActive: t.lastActive,
       isPinned: t.isPinned,
+      isPreview: t.isPreview,
     }))
     .filter(t => t.note != null) as EditorTab[];
 

--- a/packages/marqus-desktop/src/renderer/components/Editor.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Editor.tsx
@@ -103,6 +103,9 @@ const setContent: Listener<"editor.setContent"> = async ({ value }, ctx) => {
     if (prev.editor.tabs[index].isNewNote) {
       delete prev.editor.tabs[index].isNewNote;
     }
+    if (prev.editor.tabs[index].isPreview) {
+      delete prev.editor.tabs[index].isPreview;
+    }
 
     return {
       editor: {

--- a/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
@@ -29,6 +29,7 @@ export interface EditorTabProps {
   noteName: string;
   active?: boolean;
   isPinned?: boolean;
+  isPreview?: boolean;
   onClick: (noteId: string) => void;
   onClose: (noteId: string) => void;
   onUnpin: (noteId: string) => void;
@@ -109,7 +110,7 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
             <StyledTab active={active}>
               <FlexRow>
                 <StyledNoteIcon icon={faFile} size="lg" />
-                <StyledText>{noteName}</StyledText>
+                <StyledText isPreview={props.isPreview}>{noteName}</StyledText>
               </FlexRow>
             </StyledTab>
           </CursorFollower>,
@@ -148,7 +149,7 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
         <StyledTab ref={wrapper} title={notePath} active={active}>
           <FlexRow>
             <StyledNoteIcon icon={faFile} size="lg" />
-            <StyledText>{noteName}</StyledText>
+            <StyledText isPreview={props.isPreview}>{noteName}</StyledText>
           </FlexRow>
           {action}
         </StyledTab>
@@ -209,13 +210,15 @@ const StyledTab = styled.a<{ active?: boolean }>`
   }
 `;
 
-const StyledText = styled.span`
+const StyledText = styled.span<{ isPreview?: boolean }>`
   font-size: 1.2rem;
   font-weight: 500;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
   min-width: 0;
+
+  font-style: ${p => (p.isPreview ? "italic" : "normal")};
 `;
 
 const StyledDeleteIcon = styled(Icon)`

--- a/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
@@ -232,10 +232,15 @@ export function EditorToolbar(props: EditorToolbarProps): JSX.Element {
     }
 
     ctx.setCache(prev => {
-      const newlyClosedTabs: ClosedEditorTab[] = noteIdsToClose.map(noteId => ({
-        noteId,
-        previousIndex: editor.tabs.findIndex(t => t.note.id === noteId),
-      }));
+      const newlyClosedTabs: ClosedEditorTab[] = noteIdsToClose.map(noteId => {
+        const previousIndex = editor.tabs.findIndex(t => t.note.id === noteId);
+
+        return {
+          noteId,
+          previousIndex,
+          isPreview: editor.tabs[previousIndex].isPreview,
+        };
+      });
 
       const closedTabs = [...newlyClosedTabs, ...prev.closedTabs];
 
@@ -501,7 +506,7 @@ export const reopenClosedTab: Listener<"editor.reopenClosedTab"> = async (
     return;
   }
 
-  const { noteId, previousIndex } = closedTabs[0];
+  const { noteId, previousIndex, isPreview } = closedTabs[0];
   ctx.setCache(prev => {
     const closedTabs = prev.closedTabs.slice(1);
 
@@ -522,7 +527,7 @@ export const reopenClosedTab: Listener<"editor.reopenClosedTab"> = async (
     const { tabs } = prev.editor;
 
     const newIndex = Math.min(previousIndex, tabs.length);
-    tabs.splice(newIndex, 0, { note });
+    tabs.splice(newIndex, 0, { note, isPreview });
 
     return {
       editor: {

--- a/packages/marqus-desktop/src/shared/ui/app.ts
+++ b/packages/marqus-desktop/src/shared/ui/app.ts
@@ -54,12 +54,12 @@ export interface Cache {
   closedTabs: ClosedEditorTab[];
 }
 
-export type ClosedEditorTab = { noteId: string; previousIndex: number };
-
 export type ModelViewState = {
   model?: monaco.editor.ITextModel;
   viewState?: monaco.editor.ICodeEditorViewState;
 };
+
+export type ClosedEditorTab = { noteId: string; previousIndex: number };
 
 // If a note was deleted but was referenced elsewhere in the ui state we need to
 // clear out all references to it otherwise things will bork.

--- a/packages/marqus-desktop/src/shared/ui/app.ts
+++ b/packages/marqus-desktop/src/shared/ui/app.ts
@@ -60,7 +60,11 @@ export type ModelViewState = {
   viewState?: monaco.editor.ICodeEditorViewState;
 };
 
-export type ClosedEditorTab = { noteId: string; previousIndex: number };
+export type ClosedEditorTab = {
+  noteId: string;
+  previousIndex: number;
+  isPreview?: boolean;
+};
 
 // If a note was deleted but was referenced elsewhere in the ui state we need to
 // clear out all references to it otherwise things will bork.

--- a/packages/marqus-desktop/src/shared/ui/app.ts
+++ b/packages/marqus-desktop/src/shared/ui/app.ts
@@ -47,6 +47,7 @@ export interface EditorTab {
   lastActive?: Date;
   isNewNote?: boolean;
   isPinned?: boolean;
+  isPreview?: boolean;
 }
 
 export interface Cache {
@@ -129,6 +130,7 @@ export interface SerializedEditorTab {
   lastActive?: Date;
   viewState?: monaco.editor.ICodeEditorViewState;
   isPinned?: boolean;
+  isPreview?: boolean;
 }
 
 export function serializeAppState(
@@ -152,6 +154,7 @@ export function serializeAppState(
         lastActive: t.lastActive,
         viewState: cache?.modelViewStates[t.note.id]?.viewState,
         isPinned: t.isPinned,
+        isPreview: t.isPreview,
       })),
     },
   };

--- a/packages/marqus-desktop/test/renderer/components/EditorToolbar.spec.tsx
+++ b/packages/marqus-desktop/test/renderer/components/EditorToolbar.spec.tsx
@@ -94,7 +94,7 @@ test("editor.openTab works with note paths too", async () => {
   });
 
   ({ editor } = store.current.state);
-  expect(editor.tabs[1]!.note.id).toBe("4");
+  expect(editor.tabs[0]!.note.id).toBe("4");
   expect(editor.activeTabNoteId).toBe("4");
 });
 


### PR DESCRIPTION
Opening a tab will put it in preview mode now. This prevents the toolbar from being spammed with a ton of tabs if the user is rapidly switching through tabs looking for something.