### PR TITLE
Reduce lag in shortcut system

### DIFF
--- a/packages/marqus-desktop/src/renderer/components/Editor.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Editor.tsx
@@ -33,11 +33,13 @@ export function Editor(props: EditorProps): JSX.Element {
     store.on("editor.setContent", setContent);
     store.on("editor.save", save);
     store.on("editor.toggleView", toggleView);
+    store.on("editor.setModelViewState", setModelViewState);
 
     return () => {
       store.off("editor.setContent", setContent);
       store.off("editor.save", save);
       store.off("editor.toggleView", toggleView);
+      store.off("editor.setModelViewState", setModelViewState);
     };
   }, [store]);
 
@@ -86,6 +88,11 @@ const debouncedInvoker = debounce(
   NOTE_SAVE_INTERVAL_MS,
 ) as unknown as Ipc;
 
+// N.B. setContent and setViewState are stored in the parent Editor component
+// instead of Monaco because they may be invoked after the Monaco component has
+// been unmounted due to how we debounce / flush the debounced functions
+// on unmount.
+
 const setContent: Listener<"editor.setContent"> = async ({ value }, ctx) => {
   if (value == null) {
     return;
@@ -124,6 +131,22 @@ const setContent: Listener<"editor.setContent"> = async ({ value }, ctx) => {
   });
 
   await debouncedInvoker("notes.update", noteId, { content });
+};
+
+export const setModelViewState: Listener<"editor.setModelViewState"> = (
+  { value },
+  ctx,
+) => {
+  // TODO: Can we make listener parameters required?
+  if (value == null || value.noteId == null || value.modelViewState == null) {
+    return;
+  }
+
+  ctx.setCache({
+    modelViewStates: {
+      [value.noteId]: value.modelViewState,
+    },
+  });
 };
 
 const toggleView: Listener<"editor.toggleView"> = (_, ctx) => {

--- a/packages/marqus-desktop/src/renderer/components/Monaco.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Monaco.tsx
@@ -57,13 +57,11 @@ export function Monaco(props: MonacoProps): JSX.Element {
     store.on("editor.boldSelectedText", boldSelectedText);
     store.on("editor.italicSelectedText", italicSelectedText);
     store.on("editor.selectAllText", selectAllText);
-    store.on("editor.setModelViewState", setModelViewState);
 
     return () => {
       store.off("editor.boldSelectedText", boldSelectedText);
       store.off("editor.italicSelectedText", italicSelectedText);
       store.off("editor.selectAllText", selectAllText);
-      store.off("editor.setModelViewState", setModelViewState);
     };
   }, [store]);
 
@@ -197,6 +195,11 @@ export function Monaco(props: MonacoProps): JSX.Element {
     }
 
     return () => {
+      // Flush debounced handlers to ensure any final changes are made when the
+      // editor switches to view mode.
+      onViewStateChange.flush();
+      onModelChange.flush();
+
       resizeObserver?.disconnect();
 
       if (monacoEditor.current != null) {
@@ -468,19 +471,3 @@ export function disableKeybinding(
     () => void undefined,
   );
 }
-
-export const setModelViewState: Listener<"editor.setModelViewState"> = (
-  { value },
-  ctx,
-) => {
-  // TODO: Can we make listener parameters required?
-  if (value == null || value.noteId == null || value.modelViewState == null) {
-    return;
-  }
-
-  ctx.setCache({
-    modelViewStates: {
-      [value.noteId]: value.modelViewState,
-    },
-  });
-};


### PR DESCRIPTION
# Changes
- Fixed markdown changes being lost when changing to view mode too fast.
- Reduce the amount of renders to reduce the lag when typing fast.

# Reasoning
Turns out the lag wasn't because we were dispatching store actions too fast when typing. It was actually because of the shortcut system was triggering re-renders on each key change. Each key typed would trigger two re-renders (one for keyDown, one for keyUp) so typing fast would spam re-renders.

The new setup uses refs and callbacks to handle changes so `useShortcuts` won't trigger re-renders.