### PR TITLE
Scroll to note in sidebar

### DIFF
--- a/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
@@ -336,6 +336,7 @@ export function EditorToolbar(props: EditorToolbarProps): JSX.Element {
     store.on("editor.pinTab", pinTab);
     store.on("editor.unpinTab", unpinTab);
     store.on("editor.moveTab", moveTab);
+    store.on("editor.revealTabNoteInSidebar", revealTabNoteInSidebar);
 
     window.addEventListener("mouseup", onMouseUp);
 
@@ -360,6 +361,7 @@ export function EditorToolbar(props: EditorToolbarProps): JSX.Element {
       store.off("editor.pinTab", pinTab);
       store.off("editor.unpinTab", unpinTab);
       store.off("editor.moveTab", moveTab);
+      store.off("editor.revealTabNoteInSidebar", revealTabNoteInSidebar);
 
       window.removeEventListener("mouseup", onMouseUp);
     };
@@ -668,6 +670,33 @@ export const moveTab: Listener<"editor.moveTab"> = async ({ value }, ctx) => {
     return {
       editor: {
         tabs,
+      },
+    };
+  });
+};
+
+export const revealTabNoteInSidebar: Listener<
+  "editor.revealTabNoteInSidebar"
+> = async ({ value }, ctx) => {
+  if (value == null) {
+    return;
+  }
+
+  // The note we want to show in the sidebar may be hidden due to a collapsed
+  // parent so we expand any if needed.
+  const { notes } = ctx.getState();
+  const noteToReveal = getNoteById(notes, value);
+  const noteToRevealParentIds = getParents(noteToReveal, notes).map(n => n.id);
+
+  ctx.setUI(prev => {
+    const prevExpanded = prev.sidebar.expanded ?? [];
+    const newExpanded = uniq([...prevExpanded, ...noteToRevealParentIds]);
+
+    return {
+      sidebar: {
+        selected: [noteToReveal.id],
+        scrollToNoteId: value,
+        expanded: newExpanded,
       },
     };
   });

--- a/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
@@ -494,6 +494,14 @@ export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
     ctx.focus([Section.Editor], { overwrite: true });
   }
 
+  if (ev.value.scrollTo) {
+    ctx.setUI({
+      sidebar: {
+        scrollToNoteId: activeTabNoteId,
+      },
+    });
+  }
+
   cleanupClosedTabsCache(ctx);
 };
 

--- a/packages/marqus-desktop/src/renderer/components/Sidebar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Sidebar.tsx
@@ -25,7 +25,7 @@ import { SidebarNewNoteButton } from "./SidebarNewNoteButton";
 import { Section } from "../../shared/ui/app";
 import { deleteNoteIfConfirmed } from "../utils/deleteNoteIfConfirmed";
 import { cleanupClosedTabsCache, openTabsForNotes } from "./EditorToolbar";
-import { math, remToPx, stripUnit } from "polished";
+import { remToPx, stripUnit } from "polished";
 
 const EXPANDED_ICON = faCaretDown;
 const COLLAPSED_ICON = faCaretRight;

--- a/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
+++ b/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
@@ -40,6 +40,7 @@ interface SidebarMenuProps {
 
 export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
   const {
+    id,
     title,
     value,
     depth,
@@ -56,7 +57,7 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
 
   const [cursorEl, setCursorEl] = useState<JSX.Element | undefined>();
   const cursorElRef = useRef<HTMLDivElement | null>(null);
-  const { width } = store.state.sidebar;
+  const { width, scrollToNoteId } = store.state.sidebar;
 
   const onDragHandler = useCallback(
     (drag: MouseDrag | null) => {
@@ -115,6 +116,13 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
     disabled: state.sidebar.input != null,
   });
 
+  // Scroll to menu if it matches the scrollToNoteId
+  useEffect(() => {
+    if (scrollToNoteId != null && scrollToNoteId === id) {
+      $(menuRef.current!.parentElement!).scrollTo(menuRef.current!, 0);
+    }
+  }, [scrollToNoteId, id]);
+
   return (
     <>
       <SidebarRow
@@ -124,7 +132,7 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
         depth={depth}
         hasIcon={Boolean(icon)}
         onClick={onClick}
-        {...{ [SIDEBAR_MENU_ATTRIBUTE]: props.id }}
+        {...{ [SIDEBAR_MENU_ATTRIBUTE]: id }}
       >
         {icon && (
           <StyledMenuIcon

--- a/packages/marqus-desktop/src/renderer/components/SidebarSearch.tsx
+++ b/packages/marqus-desktop/src/renderer/components/SidebarSearch.tsx
@@ -71,6 +71,7 @@ export function SidebarSearch(props: SidebarSearchProps): JSX.Element {
             note: n.id,
             active: n.id,
             focus: true,
+            scrollTo: true,
           })
         }
       >

--- a/packages/marqus-desktop/src/renderer/menus/contextMenu.ts
+++ b/packages/marqus-desktop/src/renderer/menus/contextMenu.ts
@@ -147,6 +147,14 @@ export function useContextMenu(store: Store, config: Config): void {
             }
 
             items.push({
+              label: "Reveal note in sidebar",
+              type: "normal",
+              event: "editor.revealTabNoteInSidebar",
+              eventInput: tabNoteId,
+              shortcut: shortcutLabels["editor.revealTabNoteInSidebar"],
+            });
+
+            items.push({
               type: "separator",
             });
 

--- a/packages/marqus-desktop/src/shared/ui/app.ts
+++ b/packages/marqus-desktop/src/shared/ui/app.ts
@@ -32,6 +32,7 @@ export interface Sidebar {
   selected?: string[];
   expanded?: string[];
   sort: NoteSort;
+  scrollToNoteId?: string;
 }
 
 export interface Editor {

--- a/packages/marqus-desktop/src/shared/ui/events.ts
+++ b/packages/marqus-desktop/src/shared/ui/events.ts
@@ -78,6 +78,7 @@ export interface UIEvents {
   "editor.previousTab": void;
   "editor.nextTab": void;
   "editor.moveTab": { noteId: string; newIndex: number };
+  "editor.revealTabNoteInSidebar": string;
   "editor.updateTabsScroll": number;
   "editor.boldSelectedText": void;
   "editor.italicSelectedText": void;

--- a/packages/marqus-desktop/src/shared/ui/events.ts
+++ b/packages/marqus-desktop/src/shared/ui/events.ts
@@ -59,7 +59,12 @@ export interface UIEvents {
   "editor.setContent": { noteId: string; content: string };
   "editor.updateScroll": number;
   "editor.openTab":
-    | { note: string | string[]; active?: string; focus?: boolean }
+    | {
+        note: string | string[];
+        active?: string;
+        focus?: boolean;
+        scrollTo?: boolean;
+      }
     | undefined;
   "editor.pinTab": string;
   "editor.unpinTab": string;

--- a/packages/marqus-desktop/test/renderer/components/EditorToolbar.spec.tsx
+++ b/packages/marqus-desktop/test/renderer/components/EditorToolbar.spec.tsx
@@ -1004,7 +1004,7 @@ test("editor.moveTab attempt to move regular tab before pinned tab", async () =>
   expect(editor.tabs[3].note.id).toBe(notes[2].id);
 });
 
-test("editor.moveNote move pinned tab to right", async () => {
+test("editor.moveTab move pinned tab to right", async () => {
   const notes = [
     createNote({ id: "1", name: "foo" }),
     createNote({ id: "2", name: "bar" }),
@@ -1056,7 +1056,7 @@ test("editor.moveNote move pinned tab to right", async () => {
   expect(editor.tabs[3].note.id).toBe(notes[3].id);
 });
 
-test("editor.moveNote move pinned tab to left", async () => {
+test("editor.moveTab move pinned tab to left", async () => {
   const notes = [
     createNote({ id: "1", name: "foo" }),
     createNote({ id: "2", name: "bar" }),
@@ -1158,4 +1158,62 @@ test("editor.moveTab try to move pinned tab past regular tab", async () => {
   expect(editor.tabs[1].note.id).toBe(notes[0].id);
   expect(editor.tabs[2].note.id).toBe(notes[2].id);
   expect(editor.tabs[3].note.id).toBe(notes[3].id);
+});
+
+test("editor.revealTabNoteInSidebar", async () => {
+  const notes = [
+    createNote({ id: "1", name: "foo" }),
+    createNote({
+      id: "2",
+      name: "bar",
+      children: [
+        createNote({
+          id: "3",
+          name: "baz",
+          children: [createNote({ id: "4", name: "baq" })],
+        }),
+      ],
+    }),
+    createNote({
+      id: "5",
+      name: "rando-1",
+      children: [
+        createNote({
+          id: "6",
+          name: "rando-2",
+        }),
+      ],
+    }),
+  ];
+  const store = createStore({
+    notes,
+    sidebar: {
+      selected: [],
+      expanded: ["5"],
+    },
+    editor: {
+      activeTabNoteId: "0",
+      tabs: [
+        createTab({
+          note: notes[0],
+          lastActive: subHours(new Date(), 1),
+          isPinned: true,
+        }),
+        createTab({
+          note: notes[1].children[0].children[0],
+          lastActive: subHours(new Date(), 2),
+          isPinned: true,
+        }),
+      ],
+    },
+  });
+
+  render(<EditorToolbar store={store.current} />);
+  await act(async () => {
+    await store.current.dispatch("editor.revealTabNoteInSidebar", "4");
+  });
+
+  const { sidebar } = store.current.state;
+  expect(sidebar.selected).toEqual(["4"]);
+  expect(sidebar.expanded).toEqual(expect.arrayContaining(["5", "2", "3"]));
 });

--- a/packages/marqus-desktop/test/renderer/components/EditorToolbar.spec.tsx
+++ b/packages/marqus-desktop/test/renderer/components/EditorToolbar.spec.tsx
@@ -98,7 +98,7 @@ test("editor.openTab works with note paths too", async () => {
   expect(editor.activeTabNoteId).toBe("4");
 });
 
-test("editor.openTab removes tabs from closedTab", async () => {
+test("editor.openTab removes tabs from closedTabs", async () => {
   const store = createStore(
     {
       notes: [


### PR DESCRIPTION
- Right clicking a tab gives the option to reveal the note in the sidebar.
- Opening a note from search will scroll the sidebar to show it.