### PR TITLE
Add mock and rename log to logger for consistency

### DIFF
--- a/packages/marqus-desktop/src/renderer/App.tsx
+++ b/packages/marqus-desktop/src/renderer/App.tsx
@@ -22,7 +22,7 @@ import { useContextMenu } from "./menus/contextMenu";
 import { Editor } from "./components/Editor";
 import { h100, w100 } from "./css";
 import { Config } from "../shared/domain/config";
-import { log } from "./logger";
+import { logger } from "./logger";
 import { arrayify } from "../shared/utils";
 import { NoteDirectoryModal } from "./components/NoteDirectoryModal";
 import { Shortcut } from "../shared/domain/shortcut";
@@ -40,7 +40,7 @@ async function main() {
     initialState = loadedState.state;
     initialCache = loadedState.cache;
   } catch (e) {
-    await log.error("Fatal: Failed to initialize the app.", e as Error);
+    await logger.error("Fatal: Failed to initialize the app.", e as Error);
     await promptFatal("Failed to initialize app.", e as Error);
     return;
   }
@@ -90,7 +90,7 @@ export function App(props: AppProps): JSX.Element {
     store.on("focus.pop", pop);
 
     const onError = async (err: ErrorEvent) => {
-      await log.error("Uncaught Error:", err.error);
+      await logger.error("Uncaught Error:", err.error);
     };
     window.addEventListener("error", onError);
 

--- a/packages/marqus-desktop/src/renderer/components/SidebarNewNoteButton.tsx
+++ b/packages/marqus-desktop/src/renderer/components/SidebarNewNoteButton.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import { PropsWithChildren } from "react";
 import styled from "styled-components";
 import { pb2 } from "../css";
-import { log } from "../logger";
+import { logger } from "../logger";
 import { Store } from "../store";
 import { Icon } from "./shared/Icon";
 

--- a/packages/marqus-desktop/src/renderer/io/shortcuts.ts
+++ b/packages/marqus-desktop/src/renderer/io/shortcuts.ts
@@ -11,7 +11,7 @@ import { sleep } from "../../shared/utils";
 import { Shortcut } from "../../shared/domain/shortcut";
 import { UIEventType } from "../../shared/ui/events";
 import { Section } from "../../shared/ui/app";
-import { log } from "../logger";
+import { logger } from "../logger";
 import { BrowserWindowEvent, IpcChannel } from "../../shared/ipc";
 
 const INITIAL_DELAY_MS = 300;
@@ -112,7 +112,7 @@ export function useShortcuts(store: Store): void {
       if (!ev.repeat) {
         const key = parseKeyCode(ev.code);
         if (key == null) {
-          void log.info(`Unknown key: ${ev.code}`);
+          void logger.info(`Unknown key: ${ev.code}`);
           return;
         }
 

--- a/packages/marqus-desktop/src/renderer/logger.ts
+++ b/packages/marqus-desktop/src/renderer/logger.ts
@@ -7,7 +7,7 @@ if (!isTest() && getProcessType() !== "renderer") {
   );
 }
 
-export const log: Logger = {
+export const logger: Logger = {
   info: async message => {
     // eslint-disable-next-line no-console
     console.log(message);

--- a/packages/marqus-desktop/src/renderer/store.ts
+++ b/packages/marqus-desktop/src/renderer/store.ts
@@ -7,7 +7,7 @@ import { Note } from "../shared/domain/note";
 import { Shortcut } from "../shared/domain/shortcut";
 import { UIEventType, UIEventInput } from "../shared/ui/events";
 import { Section, AppState, serializeAppState } from "../shared/ui/app";
-import { log } from "./logger";
+import { logger } from "./logger";
 import { arrayify } from "../shared/utils";
 import { Cache } from "../shared/ui/app";
 
@@ -205,7 +205,7 @@ export function useStore(initialState: State, initialCache?: Cache): Store {
 
       const eventListeners: any = listeners.current[event];
       if (eventListeners == null || eventListeners.length === 0) {
-        await log.debug(`No store listener found for ${event}.`);
+        await logger.debug(`No store listener found for ${event}.`);
         return;
       }
 

--- a/packages/marqus-desktop/src/renderer/utils/prompt.ts
+++ b/packages/marqus-desktop/src/renderer/utils/prompt.ts
@@ -1,5 +1,5 @@
 import { PromptOptions } from "../../shared/ui/prompt";
-import { log } from "../logger";
+import { logger } from "../logger";
 
 const { ipc } = window;
 
@@ -29,7 +29,7 @@ export const promptFatal = async (
   });
 
   if (button.text === "Quit") {
-    await log.info("Shutting down.");
+    await logger.info("Shutting down.");
     await ipc("app.quit");
   } else if (button.text === "Reload") {
     await ipc("app.reload");

--- a/packages/marqus-desktop/test/renderer/App.spec.tsx
+++ b/packages/marqus-desktop/test/renderer/App.spec.tsx
@@ -3,7 +3,7 @@ import { App } from "../../src/renderer/App";
 import { createConfig } from "../__factories__/config";
 import { createCache, createState } from "../__factories__/state";
 import React from "react";
-import { log } from "../../src/renderer/logger";
+import { logger } from "../../src/renderer/logger";
 
 jest.mock("./../../src/renderer/logger");
 
@@ -16,5 +16,5 @@ test("Uncaught errors are logged.", async () => {
     fireEvent.error(window);
   });
 
-  expect(log.error).toBeCalledWith("Uncaught Error:", undefined);
+  expect(logger.error).toBeCalledWith("Uncaught Error:", undefined);
 });

--- a/packages/marqus-desktop/test/renderer/utils/prompt.spec.ts
+++ b/packages/marqus-desktop/test/renderer/utils/prompt.spec.ts
@@ -1,5 +1,7 @@
 import { promptFatal } from "../../../src/renderer/utils/prompt";
 
+jest.mock("../../../src/renderer/logger");
+
 test("promptFatal", async () => {
   const err = {
     message: "error-message",


### PR DESCRIPTION
- Mocked the logger in prompt.spec.ts to avoid it printing to console
- Renamed `log` to `logger` on renderer side for consistency.