### PR TITLE
Fix icons in Monaco ctrl+f menu

### DIFF
--- a/packages/marqus-desktop/webpack.rules.js
+++ b/packages/marqus-desktop/webpack.rules.js
@@ -24,8 +24,11 @@ module.exports = [
       "sass-loader",
     ],
   },
+  // Required to load Monaco's codicon.ttf so the icons will show in the ctrl+f
+  // menu.
+  // https://github.com/microsoft/monaco-editor/tree/main/webpack-plugin
   {
     test: /\.ttf$/,
-    use: [{ loader: "file-loader" }],
+    type: "asset/resource",
   },
 ];


### PR DESCRIPTION
They were broken because `codicon.ttf` wasn't loading correctly. This is just a small UX polish.