### PR TITLE
Don't pad every side of editor content

### DIFF
--- a/packages/marqus-desktop/src/renderer/components/Editor.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Editor.tsx
@@ -3,7 +3,6 @@ import React, { useEffect } from "react";
 import styled from "styled-components";
 import { Section } from "../../shared/ui/app";
 import { Ipc } from "../../shared/ipc";
-import { m3 } from "../css";
 import { Listener, Store } from "../store";
 import { Markdown } from "./Markdown";
 import { Monaco } from "./Monaco";
@@ -11,6 +10,7 @@ import { Focusable } from "./shared/Focusable";
 import { EditorToolbar, TOOLBAR_HEIGHT } from "./EditorToolbar";
 import { getNoteById } from "../../shared/domain/note";
 import { Config } from "../../shared/domain/config";
+import { ml3 } from "../css";
 
 const NOTE_SAVE_INTERVAL_MS = 1000;
 
@@ -79,8 +79,8 @@ const StyledContent = styled.div`
   display: flex;
   flex-direction: column;
   height: calc(100% - ${TOOLBAR_HEIGHT});
-  ${m3}
   overflow: hidden;
+  ${ml3}
 `;
 
 const debouncedInvoker = debounce(

--- a/packages/marqus-desktop/src/renderer/components/Monaco.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Monaco.tsx
@@ -383,14 +383,14 @@ export function Monaco(props: MonacoProps): JSX.Element {
   };
 
   return (
-    <StyledEditor
+    <StyledMonaco
       data-testid="monaco-container"
       ref={containerElement}
-    ></StyledEditor>
+    ></StyledMonaco>
   );
 }
 
-const StyledEditor = styled.div`
+const StyledMonaco = styled.div`
   flex-grow: 1;
   height: calc(100% - ${TOOLBAR_HEIGHT});
 `;


### PR DESCRIPTION
Fixed editor UI so it's not padding the content to the right of the scroll bar, and also avoids making the monaco ctrl+f menu stop floating.