### PR TITLE
Make it harder to unpreview tabs

### DIFF
--- a/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorTab.tsx
@@ -31,6 +31,7 @@ export interface EditorTabProps {
   isPinned?: boolean;
   isPreview?: boolean;
   onClick: (noteId: string) => void;
+  onDoubleClick: (noteId: string) => void;
   onClose: (noteId: string) => void;
   onUnpin: (noteId: string) => void;
   onDrag: (noteId: string, drag: TabDrag) => void;
@@ -145,6 +146,7 @@ export function EditorTab(props: EditorTabProps): JSX.Element {
       <StyledWrapper
         {...{ [EDITOR_TAB_ATTRIBUTE]: noteId }}
         onClick={() => props.onClick(noteId)}
+        onDoubleClick={() => props.onDoubleClick(noteId)}
       >
         <StyledTab ref={wrapper} title={notePath} active={active}>
           <FlexRow>

--- a/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
@@ -44,6 +44,10 @@ export function EditorToolbar(props: EditorToolbarProps): JSX.Element {
       await store.dispatch("editor.openTab", { note: noteId, active: noteId });
     };
 
+    const onDoubleClick = async (noteId: string) => {
+      await store.dispatch("editor.exitTabPreviewMode", noteId);
+    };
+
     const onClose = async (noteId: string) => {
       await store.dispatch("editor.closeTab", noteId);
     };
@@ -107,6 +111,7 @@ export function EditorToolbar(props: EditorToolbarProps): JSX.Element {
           isPinned={tab.isPinned}
           isPreview={tab.isPreview}
           onClick={onClick}
+          onDoubleClick={onDoubleClick}
           onClose={onClose}
           onUnpin={onUnpin}
           onDrag={onDrag}
@@ -337,6 +342,7 @@ export function EditorToolbar(props: EditorToolbarProps): JSX.Element {
     store.on("editor.unpinTab", unpinTab);
     store.on("editor.moveTab", moveTab);
     store.on("editor.revealTabNoteInSidebar", revealTabNoteInSidebar);
+    store.on("editor.exitTabPreviewMode", exitTabPreviewMode);
 
     window.addEventListener("mouseup", onMouseUp);
 
@@ -362,6 +368,7 @@ export function EditorToolbar(props: EditorToolbarProps): JSX.Element {
       store.off("editor.unpinTab", unpinTab);
       store.off("editor.moveTab", moveTab);
       store.off("editor.revealTabNoteInSidebar", revealTabNoteInSidebar);
+      store.off("editor.exitTabPreviewMode", exitTabPreviewMode);
 
       window.removeEventListener("mouseup", onMouseUp);
     };
@@ -505,6 +512,29 @@ export const openTab: Listener<"editor.openTab"> = async (ev, ctx) => {
   }
 
   cleanupClosedTabsCache(ctx);
+};
+
+export const exitTabPreviewMode: Listener<"editor.exitTabPreviewMode"> = async (
+  ev,
+  ctx,
+) => {
+  if (ev.value == null) {
+    return;
+  }
+
+  const noteId = ev.value;
+  ctx.setUI(ui => {
+    const tab = ui.editor.tabs.find(t => t.note.id === noteId);
+    if (tab == null) {
+      return ui;
+    }
+    if (!tab.isPreview) {
+      return ui;
+    }
+
+    tab.isPreview = false;
+    return ui;
+  });
 };
 
 export const reopenClosedTab: Listener<"editor.reopenClosedTab"> = async (

--- a/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/EditorToolbar.tsx
@@ -731,10 +731,6 @@ export function openTabsForNotes(
         tabs = tabs.filter(t => !t.isPreview);
       }
     }
-    // Second open of a tab takes it out of preview mode.
-    else if (tab.isPreview) {
-      delete tab.isPreview;
-    }
 
     tab.lastActive = new Date();
 

--- a/packages/marqus-desktop/src/renderer/components/Sidebar.tsx
+++ b/packages/marqus-desktop/src/renderer/components/Sidebar.tsx
@@ -292,6 +292,10 @@ export function renderMenus(
       });
     };
 
+    const onDoubleClick = async () => {
+      await store.dispatch("editor.exitTabPreviewMode", note.id);
+    };
+
     let icon;
     if (hasChildren || hasInput) {
       icon = isExpanded ? EXPANDED_ICON : COLLAPSED_ICON;
@@ -322,6 +326,7 @@ export function renderMenus(
           title={noteFullPath}
           value={note.name}
           onClick={onClick}
+          onDoubleClick={onDoubleClick}
           onIconClick={async (ev: React.MouseEvent) => {
             // Prevents click of menu itself from triggering
             ev.stopPropagation();

--- a/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
+++ b/packages/marqus-desktop/src/renderer/components/SidebarMenu.tsx
@@ -39,6 +39,7 @@ interface SidebarMenuProps {
   value: string;
   isSelected: boolean;
   onClick: () => void;
+  onDoubleClick?: () => void;
   onIconClick: (ev: React.MouseEvent) => void;
   onDrag: (newParent?: string) => void;
   store: Store;
@@ -53,6 +54,7 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
     icon,
     isSelected,
     onClick,
+    onDoubleClick,
     onIconClick,
     onDrag,
     store,
@@ -160,6 +162,7 @@ export function SidebarMenu(props: SidebarMenuProps): JSX.Element {
         depth={depth}
         hasIcon={Boolean(icon)}
         onClick={onClick}
+        onDoubleClick={onDoubleClick}
         {...{ [SIDEBAR_MENU_ATTRIBUTE]: id }}
       >
         {icon && (

--- a/packages/marqus-desktop/src/shared/ui/events.ts
+++ b/packages/marqus-desktop/src/shared/ui/events.ts
@@ -90,6 +90,7 @@ export interface UIEvents {
     noteId: string;
     modelViewState: ModelViewState;
   };
+  "editor.exitTabPreviewMode": string;
 
   // Focus Tracker
   "focus.push": Section | Section[];
@@ -176,6 +177,7 @@ export const LIST_OF_EVENTS: (keyof UIEvents)[] = [
   "editor.italicSelectedText",
   "editor.selectAllText",
   "editor.setModelViewState",
+  "editor.exitTabPreviewMode",
 
   // Focus Tracker
   "focus.push",


### PR DESCRIPTION
The old behavior of clicking a note in the sidebar a second time to take it out of preview has been changed to run when a note is double clicked now.

This makes it harder to accidentally take notes out of preview since a double click is harder to do on accident.